### PR TITLE
chore: Add comments for properties that come from additional API endpoints

### DIFF
--- a/src/pyenphase/models/dry_contacts.py
+++ b/src/pyenphase/models/dry_contacts.py
@@ -1,5 +1,5 @@
 """Model for the Enpower dry contact relays."""
-# Data Source: URL_DRY_CONTACT_STATUS, URL_DRY_CONTACT_SETTINGS
+# Data Source: URL_DRY_CONTACT_SETTINGS (primary) & URL_DRY_CONTACT_STATUS
 
 from typing import Any
 
@@ -12,11 +12,13 @@ class EnvoyDryContact:
     @property
     def id(self) -> str:
         """Return the relay ID."""
+        # Matches between both API endpoints
         return self._data["id"]
 
     @property
     def status(self) -> str:
         """Return the relay status (opened/closed)."""
+        # From URL_DRY_CONTACT_STATUS
         return self._data["status"]
 
     @property

--- a/src/pyenphase/models/encharge.py
+++ b/src/pyenphase/models/encharge.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-# Data Source: URL_ENSEMBLE_INVENTORY, URL_ENCHARGE_BATTERY
+# Data Source: URL_ENSEMBLE_INVENTORY (primary) & URL_ENCHARGE_BATTERY
 
 
 class EnvoyEncharge:
@@ -104,6 +104,7 @@ class EnvoyEncharge:
     @property
     def serial_number(self) -> str:
         """Return the Encharge serial number."""
+        # Matches both API endpoints
         return self._data["serial_num"]
 
     @property
@@ -124,14 +125,17 @@ class EnvoyEncharge:
     @property
     def apparent_power_mva(self) -> int:
         """Return the apparent power in MVA."""
+        # From URL_ENCHARGE_BATTERY
         return self._data["apparent_power_mva"]
 
     @property
     def real_power_mw(self) -> int:
         """Return the real power in MW."""
+        # From URL_ENCHARGE_BATTERY
         return self._data["real_power_mw"]
 
     @property
     def soc(self) -> int:
         """Return the state of charge."""
+        # From URL_ENCHARGE_BATTERY
         return self._data["soc"]


### PR DESCRIPTION
The Encharge and Dry Contacts models have properties that come from 2 different API endpoints. This adds comments to specify a primary API endpoint that returns the majority of the data, and comments to specify which properties come from other API endpoints. Referenced everything by their constant name in const.py