### PR TITLE
fix: adjust timeouts for when envoy is having trouble with DNS

### DIFF
--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -1,8 +1,13 @@
+import httpx
+
 # System Production
 URL_PRODUCTION_INVERTERS = "/api/v1/production/inverters"
 URL_PRODUCTION_V1 = "/api/v1/production"
 URL_PRODUCTION_JSON = "/production.json"
 URL_PRODUCTION = "/production"
+
+# Authentication
+URL_AUTH_CHECK_JWT = "/auth/check_jwt"
 
 # Battery and Enpower Status
 URL_DRY_CONTACT_STATUS = "/ivp/ensemble/dry_contacts"
@@ -17,3 +22,12 @@ URL_TARIFF = "/admin/lib/tariff"
 URL_GEN_CONFIG = "/ivp/ss/gen_config"
 URL_GEN_MODE = "/ivp/ss/gen_mode"
 URL_GEN_SCHEDULE = "/ivp/ss/gen_schedule"
+
+
+LOCAL_TIMEOUT = httpx.Timeout(
+    # The envoy can be slow to respond but fast to connect to we
+    # need to set a long timeout for the read and a short timeout
+    # for the connect
+    timeout=10.0,
+    read=60.0,
+)

--- a/src/pyenphase/firmware.py
+++ b/src/pyenphase/firmware.py
@@ -1,7 +1,9 @@
 import httpx
 from awesomeversion import AwesomeVersion
 from lxml import etree  # nosec
+from tenacity import retry, retry_if_exception_type, wait_random_exponential
 
+from .const import LOCAL_TIMEOUT
 from .exceptions import EnvoyFirmwareCheckError, EnvoyFirmwareFatalCheckError
 
 
@@ -24,11 +26,31 @@ class EnvoyFirmware:
         self._serial_number: str | None = None
         self._part_number: str | None = None
 
+    @retry(
+        retry=retry_if_exception_type(httpx.HTTPError),
+        wait=wait_random_exponential(multiplier=2, max=10),
+    )
+    async def _get_info(self) -> None:
+        """Obtain the firmware version for Envoy authentication."""
+        try:
+            return await self._client.get(
+                f"https://{self._host}/info", timeout=LOCAL_TIMEOUT
+            )
+        except (httpx.ConnectError, httpx.TimeoutException):
+            # Firmware < 7.0.0 does not support HTTPS so we need to try HTTP
+            # as a fallback, worse sometimes http will redirect to https://localhost
+            # which is not helpful
+            return await self._client.get(
+                f"http://{self._host}/info", timeout=LOCAL_TIMEOUT
+            )
+
     async def setup(self) -> None:
         """Obtain the firmware version for Envoy authentication."""
         # <envoy>/info will return XML with the firmware version
         try:
-            result = await self._client.get(f"http://{self._host}/info")
+            result = await self._get_info()
+        except httpx.TimeoutException:
+            raise EnvoyFirmwareFatalCheckError(500, "Timeout connecting to Envoy")
         except httpx.ConnectError:
             raise EnvoyFirmwareFatalCheckError(500, "Unable to connect to Envoy")
         except httpx.HTTPError:


### PR DESCRIPTION
If the internet connection is flakey, or offline even though we had a token, envoy setup would still timeout

We need a long read timeout for it to work as its apparently resolving the incoming host that is making the http connection

Worse then its having trouble with dns, its going to redirect to `https://localhost` 🤦 
```
HTTP/1.1 301 Moved Permanently
Server: openresty/1.17.8.1
Date: Tue, 08 Aug 2023 19:32:50 GMT
Content-Type: text/html
Content-Length: 175
Connection: close
Location: https://localhost/
```