### PR TITLE
fix: handle envoy sending bad json

### DIFF
--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -139,7 +139,7 @@ class Envoy:
 
         Probe requests are not retried on bad JSON responses.
         """
-        await self._request(endpoint)
+        return await self._request(endpoint)
 
     @retry(
         retry=retry_if_exception_type(


### PR DESCRIPTION
Sometimes the production endpoint will return bad json and we need to try again. We should not retry when probing since that will give us wrong results.

Split the request function into one that retries on bad json and one that does not for probing

fixes
```
2023-08-08 10:34:10.393 ERROR (MainThread) [homeassistant.components.enphase_envoy.coordinator] Unexpected error fetching Envoy 121729017746 data: unexpected character: line 1 column 1 (char 0)
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/helpers/update_coordinator.py", line 293, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/homeassistant/components/enphase_envoy/coordinator.py", line 151, in _async_update_data
    return (await envoy.update()).raw
            ^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/pyenphase/envoy.py", line 274, in update
    production_data = await self.request(production_endpoint)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/tenacity/_asyncio.py", line 88, in async_wrapped
    return await fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/tenacity/_asyncio.py", line 47, in __call__
    do = self.iter(retry_state=retry_state)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/tenacity/__init__.py", line 314, in iter
    return fut.result()
           ^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/tenacity/_asyncio.py", line 50, in __call__
    result = await fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/venv/lib/python3.11/site-packages/pyenphase/envoy.py", line 155, in request
    return orjson.loads(response.text)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
orjson.JSONDecodeError: unexpected character: line 1 column 1 (char 0)```