### PR TITLE
fix: add "schedule" to DryContactAction

### DIFF
--- a/src/pyenphase/models/dry_contacts.py
+++ b/src/pyenphase/models/dry_contacts.py
@@ -16,6 +16,7 @@ class DryContactStatus(StrEnum):
 class DryContactAction(StrEnum):
     APPLY = "apply"
     SHED = "shed"
+    SCHEDULE = "schedule"
     NONE = "none"
 
 


### PR DESCRIPTION
The `grid_action`, `micro_grid_action`, and `gen_action` fields in `/ivp/ss/dry_contact_settings` can also return `schedule` as a value

`schedule` means the relay/load will be active between `essential_start_time` and `essential_end_time`