### PR TITLE
feat: add support for changing settings on dry contact relays

### DIFF
--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -179,7 +179,10 @@ class Envoy:
         url = self.auth.get_endpoint_url(endpoint)
 
         if data:
-            _LOGGER.debug("Sending POST to %s with data %s", url, orjson.dumps(data))
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug(
+                    "Sending POST to %s with data %s", url, orjson.dumps(data)
+                )
             return await self._client.post(
                 url,
                 headers={**DEFAULT_HEADERS, **self.auth.headers},

--- a/src/pyenphase/models/dry_contacts.py
+++ b/src/pyenphase/models/dry_contacts.py
@@ -89,3 +89,25 @@ class EnvoyDryContactSettings:
             soc_low=relay["soc_low"],
             type=DryContactType(relay["type"]),
         )
+
+    def to_api(self) -> dict[str, Any]:
+        """Convert to API format."""
+        return {
+            "id": self.id,
+            "black_s_start": self.black_start,
+            "essential_end_time": self.essential_end_time,
+            "essential_start_time": self.essential_start_time,
+            "gen_action": self.generator_action,
+            "grid_action": self.grid_action,
+            "load_name": self.load_name,
+            # boolean values must be passed to the API as a lowercase string
+            "manual_override": str(self.manual_override).lower(),
+            "micro_grid_action": self.micro_grid_action,
+            "mode": self.mode,
+            "override": str(self.override).lower(),
+            "priority": self.priority,
+            "pv_serial_nb": self.pv_serial_nb,
+            "soc_high": self.soc_high,
+            "soc_low": self.soc_low,
+            "type": self.type,
+        }


### PR DESCRIPTION
Adds a function to change settings for the Enpower dry contacts / load shedding relays.

takeaways from reverse engineering this:
- The entire settings object for the relay you're changing has to be sent in the POST request or else the Envoy might crash
- Boolean values have to be sent as lowercase strings in the POST (or you'll get a HTTP 500 error saying the field is missing