### PR TITLE
fix: preemptively update dry contact state when toggling

### DIFF
--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -315,6 +315,8 @@ class Envoy:
         result = await self._json_request(
             URL_DRY_CONTACT_STATUS, {"dry_contacts": {"id": id, "status": "open"}}
         )
+        # The Envoy takes a few seconds before it will reflect the new state of the relay
+        # so we preemptively update it
         if self.data:
             self.data.dry_contact_status[id].status = DryContactStatus.OPEN
         return result
@@ -329,6 +331,8 @@ class Envoy:
         result = await self._json_request(
             URL_DRY_CONTACT_STATUS, {"dry_contacts": {"id": id, "status": "closed"}}
         )
+        # The Envoy takes a few seconds before it will reflect the new state of the relay
+        # so we preemptively update it
         if self.data:
             self.data.dry_contact_status[id].status = DryContactStatus.CLOSED
         return result

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -9,6 +9,8 @@ from awesomeversion import AwesomeVersion
 from envoy_utils.envoy_utils import EnvoyUtils
 from tenacity import retry, retry_if_exception_type, wait_random_exponential
 
+from pyenphase.models.dry_contacts import DryContactStatus
+
 from .auth import EnvoyAuth, EnvoyLegacyAuth, EnvoyTokenAuth
 from .const import (
     AUTH_TOKEN_MIN_VERSION,
@@ -310,9 +312,12 @@ class Envoy:
                 "This feature is not available on this Envoy."
             )
 
-        return await self._json_request(
+        result = await self._json_request(
             URL_DRY_CONTACT_STATUS, {"dry_contacts": {"id": id, "status": "open"}}
         )
+        if self.data:
+            self.data.dry_contact_status[id].status = DryContactStatus.OPEN
+        return result
 
     async def close_dry_contact(self, id: str) -> dict[str, Any]:
         """Open a dry contact relay."""
@@ -321,6 +326,9 @@ class Envoy:
                 "This feature is not available on this Envoy."
             )
 
-        return await self._json_request(
+        result = await self._json_request(
             URL_DRY_CONTACT_STATUS, {"dry_contacts": {"id": id, "status": "closed"}}
         )
+        if self.data:
+            self.data.dry_contact_status[id].status = DryContactStatus.CLOSED
+        return result

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -317,8 +317,8 @@ class Envoy:
         )
         # The Envoy takes a few seconds before it will reflect the new state of the relay
         # so we preemptively update it
-        if self.data:
-            self.data.dry_contact_status[id].status = DryContactStatus.OPEN
+        if data := self.data:
+            data.dry_contact_status[id].status = DryContactStatus.OPEN
         return result
 
     async def close_dry_contact(self, id: str) -> dict[str, Any]:
@@ -333,6 +333,6 @@ class Envoy:
         )
         # The Envoy takes a few seconds before it will reflect the new state of the relay
         # so we preemptively update it
-        if self.data:
-            self.data.dry_contact_status[id].status = DryContactStatus.CLOSED
+        if data := self.data:
+            data.dry_contact_status[id].status = DryContactStatus.CLOSED
         return result

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -317,7 +317,7 @@ class Envoy:
         )
         # The Envoy takes a few seconds before it will reflect the new state of the relay
         # so we preemptively update it
-        if data := self.data:
+        if data := self.data:  # nosec
             data.dry_contact_status[id].status = DryContactStatus.OPEN
         return result
 
@@ -333,6 +333,6 @@ class Envoy:
         )
         # The Envoy takes a few seconds before it will reflect the new state of the relay
         # so we preemptively update it
-        if data := self.data:
+        if data := self.data:  # nosec
             data.dry_contact_status[id].status = DryContactStatus.CLOSED
         return result

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Callable
 from dataclasses import replace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import orjson
@@ -317,8 +317,9 @@ class Envoy:
         )
         # The Envoy takes a few seconds before it will reflect the new state of the relay
         # so we preemptively update it
-        if data := self.data:  # nosec
-            data.dry_contact_status[id].status = DryContactStatus.OPEN
+        if TYPE_CHECKING:
+            assert self.data is not None  # nosec
+        self.data.dry_contact_status[id].status = DryContactStatus.OPEN
         return result
 
     async def close_dry_contact(self, id: str) -> dict[str, Any]:
@@ -333,6 +334,7 @@ class Envoy:
         )
         # The Envoy takes a few seconds before it will reflect the new state of the relay
         # so we preemptively update it
-        if data := self.data:  # nosec
-            data.dry_contact_status[id].status = DryContactStatus.CLOSED
+        if TYPE_CHECKING:
+            assert self.data is not None  # nosec
+        self.data.dry_contact_status[id].status = DryContactStatus.CLOSED
         return result

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -20,6 +20,7 @@ from pyenphase.exceptions import (
     EnvoyFeatureNotAvailable,
     EnvoyProbeFailed,
 )
+from pyenphase.models.dry_contacts import DryContactStatus
 from pyenphase.models.envoy import EnvoyData
 from pyenphase.models.system_production import EnvoySystemProduction
 from pyenphase.updaters.base import EnvoyUpdater
@@ -1188,11 +1189,13 @@ async def test_with_7_x_firmware(
         )
 
         await envoy.open_dry_contact("NC1")
+        assert envoy.data.dry_contact_status["NC1"].status == DryContactStatus.OPEN
         assert respx.calls.last.request.content == orjson.dumps(
             {"dry_contacts": {"id": "NC1", "status": "open"}}
         )
 
         await envoy.close_dry_contact("NC1")
+        assert envoy.data.dry_contact_status["NC1"].status == DryContactStatus.CLOSED
         assert respx.calls.last.request.content == orjson.dumps(
             {"dry_contacts": {"id": "NC1", "status": "closed"}}
         )


### PR DESCRIPTION
The envoy will return the old state of the relay for a number of seconds after changing the state. This PR updates our open/close functions to preemptively update the state we're storing in the EnvoyData which helps with programs like Home Assistant where the switch would toggle back and forth due to the previous state being returned.