### PR TITLE
feat: add ivp/meters and ivp/meters/readings to fixture collector

### DIFF
--- a/devtools/fixture_collector.py
+++ b/devtools/fixture_collector.py
@@ -44,6 +44,8 @@ async def main() -> None:
         "/ivp/sc/pvlimit",
         "/ivp/ss/pel_settings",
         "/ivp/ensemble/generator",
+        "/ivp/meters",
+        "/ivp/meters/readings",
     ]
 
     assert envoy.auth  # nosec


### PR DESCRIPTION
As first step for #69, add ivp/meters and ivp/meters/readings to fixture collector.

Be aware result are (probably) more configuration dependent than firmware dependent. These pages only apply to IQ Gateway/Envoy metered with both Production and Consumption CT installed and configured.  ivp/meters where report 'split phase' or '3 phase' based on actual configuration and net-consumption or total-consumption based on the position of the consumption CT. This implies that within same firmware there is multiple datasets coming back.