### PR TITLE
fix: handle /production returning a 401 even with the correct auth on some 3.x firmwares

### DIFF
--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -741,6 +741,33 @@ async def test_with_3_9_36_firmware_with_production_401():
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_with_3_9_36_firmware_with_production_and_production_json_401():
+    """Verify with 3.9.36 firmware when /production and /production.json throws a 401."""
+    version = "3.9.36"
+    respx.get("/info").mock(
+        return_value=Response(200, text=_load_fixture(version, "info"))
+    )
+    respx.get("/info.xml").mock(return_value=Response(200, text=""))
+    respx.get("/production").mock(return_value=Response(401))
+    respx.get("/production.json").mock(return_value=Response(401))
+    respx.get("/api/v1/production").mock(
+        return_value=Response(
+            200, json=_load_json_fixture(version, "api_v1_production")
+        )
+    )
+    respx.get("/api/v1/production/inverters").mock(
+        return_value=Response(
+            200, json=_load_json_fixture(version, "api_v1_production_inverters")
+        )
+    )
+    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+
+    with pytest.raises(EnvoyAuthenticationRequired):
+        await _get_mock_envoy()
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_with_3_17_3_firmware():
     """Verify with 3.17.3 firmware."""
     version = "3.17.3"


### PR DESCRIPTION
* 3.9.36 with correct password
 - `/production` = 401
 - `/production.json` = 200, good data
 