### PR TITLE
feat: Add initial tariff support and charge from grid functions

### DIFF
--- a/src/pyenphase/__init__.py
+++ b/src/pyenphase/__init__.py
@@ -41,4 +41,5 @@ __all__ = (
     "EnvoyEnpower",
     "EnvoyDryContactSettings",
     "EnvoyDryContactStatus",
+    "EnvoyTariff",
 )

--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -51,3 +51,4 @@ class SupportedFeatures(enum.IntFlag):
     ENCHARGE = 16
     ENPOWER = 32
     PRODUCTION = 64
+    TARIFF = 128

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -400,7 +400,7 @@ class Envoy:
             )
         self.data.tariff.storage_settings.charge_from_grid = True
         return await self._json_request(
-            URL_TARIFF, {"tariff": self.data.tariff.to_api()}, "PUT"
+            URL_TARIFF, {"tariff": self.data.tariff.to_api()}, method="PUT"
         )
 
     async def disable_charge_from_grid(self) -> dict[str, Any]:
@@ -419,5 +419,5 @@ class Envoy:
             )
         self.data.tariff.storage_settings.charge_from_grid = False
         return await self._json_request(
-            URL_TARIFF, {"tariff": self.data.tariff.to_api()}, "PUT"
+            URL_TARIFF, {"tariff": self.data.tariff.to_api()}, method="PUT"
         )

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -387,6 +387,10 @@ class Envoy:
     async def enable_charge_from_grid(self) -> dict[str, Any]:
         """Enable charge from grid for Encharge batteries."""
         self._verify_tariff_storage_or_raise()
+        if TYPE_CHECKING:
+            assert self.data is not None  # nosec
+            assert self.data.tariff is not None  # nosec
+            assert self.data.tariff.storage_settings is not None  # nosec
         self.data.tariff.storage_settings.charge_from_grid = True
         return await self._json_request(
             URL_TARIFF, {"tariff": self.data.tariff.to_api()}, method="PUT"
@@ -395,6 +399,10 @@ class Envoy:
     async def disable_charge_from_grid(self) -> dict[str, Any]:
         """Disable charge from grid for Encharge batteries."""
         self._verify_tariff_storage_or_raise()
+        if TYPE_CHECKING:
+            assert self.data is not None  # nosec
+            assert self.data.tariff is not None  # nosec
+            assert self.data.tariff.storage_settings is not None  # nosec
         self.data.tariff.storage_settings.charge_from_grid = False
         return await self._json_request(
             URL_TARIFF, {"tariff": self.data.tariff.to_api()}, method="PUT"
@@ -409,10 +417,16 @@ class Envoy:
             raise EnvoyFeatureNotAvailable(
                 "This feature is not available on this Envoy."
             )
-        if not self.data or not self.data.tariff:
+        if not self.data:
+            raise ValueError("Tried access envoy data before Envoy was queried.")
+        if TYPE_CHECKING:
+            assert self.data is not None  # nosec
+        if not self.data.tariff:
             raise ValueError(
-                "Tried to disable charge from grid before the Envoy was queried."
+                "Tried to configure charge from grid before the Envoy was queried."
             )
+        if TYPE_CHECKING:
+            assert self.data.tariff is not None  # nosec
         if not self.data.tariff.storage_settings:
             raise EnvoyFeatureNotAvailable(
                 "This feature requires Enphase Encharge or IQ Batteries."

--- a/src/pyenphase/models/envoy.py
+++ b/src/pyenphase/models/envoy.py
@@ -9,6 +9,7 @@ from .enpower import EnvoyEnpower
 from .inverter import EnvoyInverter
 from .system_consumption import EnvoySystemConsumption
 from .system_production import EnvoySystemProduction
+from .tariff import EnvoyTariff
 
 
 @dataclass(slots=True)
@@ -26,6 +27,7 @@ class EnvoyData:
         default_factory=dict
     )
     inverters: dict[str, EnvoyInverter] = field(default_factory=dict)
+    tariff: EnvoyTariff | None = None
     # Raw data is exposed so we can __eq__ the data to see if
     # anything has changed and consumers of the library can
     # avoid dispatching data if nothing has changed.

--- a/src/pyenphase/models/tariff.py
+++ b/src/pyenphase/models/tariff.py
@@ -22,7 +22,7 @@ class EnvoyTariff:
     storage_settings: EnvoyStorageSettings | None
     single_rate: dict[str, Any]
     seasons: list[Any]
-    seasons_sell: list[Any]
+    seasons_sell: list[Any] | None
 
     @classmethod
     def from_api(cls, data: dict[str, Any]) -> EnvoyTariff:
@@ -36,7 +36,7 @@ class EnvoyTariff:
             else None,
             single_rate=data["single_rate"],
             seasons=data["seasons"],
-            seasons_sell=data["seasons_sell"],
+            seasons_sell=data.get("seasons_sell"),
         )
 
     def to_api(self) -> dict[str, Any]:
@@ -45,12 +45,13 @@ class EnvoyTariff:
             "currency": self.currency,
             "single_rate": self.single_rate,
             "seasons": self.seasons,
-            "seasons_sell": self.seasons_sell,
         }
         if self.logger:
             retval["logger"] = self.logger
         if self.date:
             retval["date"] = self.date
+        if self.seasons_sell:
+            retval["seasons_sell"] = self.seasons_sell
         if self.storage_settings:
             retval["storage_settings"] = self.storage_settings.to_api()
 

--- a/src/pyenphase/models/tariff.py
+++ b/src/pyenphase/models/tariff.py
@@ -1,0 +1,92 @@
+"""Model for the Envoy tariff data."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+
+class EnvoyStorageMode(StrEnum):
+    BACKUP = "backup"
+    SELF_CONSUMPTION = "self-consumption"
+    SAVINGS = "savings-mode"
+
+
+@dataclass
+class EnvoyTariff:
+    """Model for the Envoy tariff data."""
+
+    currency: dict[str, Any]
+    logger: str | None
+    date: str | None
+    storage_settings: EnvoyStorageSettings | None
+    single_rate: dict[str, Any]
+    seasons: list[Any]
+    seasons_sell: list[Any]
+
+    @classmethod
+    def from_api(cls, data: dict[str, Any]) -> EnvoyTariff:
+        """Initialize from the API."""
+        return cls(
+            currency=data["currency"],
+            logger=data.get("logger"),
+            date=data.get("date"),
+            storage_settings=EnvoyStorageSettings.from_api(data["storage_settings"])
+            if data.get("storage_settings")
+            else None,
+            single_rate=data["single_rate"],
+            seasons=data["seasons"],
+            seasons_sell=data["seasons_sell"],
+        )
+
+    def to_api(self) -> dict[str, Any]:
+        """Convert to API format."""
+        retval = {
+            "currency": self.currency,
+            "single_rate": self.single_rate,
+            "seasons": self.seasons,
+            "seasons_sell": self.seasons_sell,
+        }
+        if self.logger:
+            retval["logger"] = self.logger
+        if self.date:
+            retval["date"] = self.date
+        if self.storage_settings:
+            retval["storage_settings"] = self.storage_settings.to_api()
+
+        return retval
+
+
+@dataclass
+class EnvoyStorageSettings:
+    """Model for the Envoy storage settings."""
+
+    mode: EnvoyStorageMode
+    operation_mode_sub_type: str
+    reserved_soc: float
+    very_low_soc: int
+    charge_from_grid: bool
+    date: str
+
+    @classmethod
+    def from_api(cls, data: dict[str, Any]) -> EnvoyStorageSettings:
+        """Initialize from the API."""
+        return cls(
+            mode=EnvoyStorageMode(data["mode"]),
+            operation_mode_sub_type=data["operation_mode_sub_type"],
+            reserved_soc=data["reserved_soc"],
+            very_low_soc=data["very_low_soc"],
+            charge_from_grid=data["charge_from_grid"],
+            date=data["date"],
+        )
+
+    def to_api(self) -> dict[str, Any]:
+        """Convert to API format."""
+        return {
+            "mode": self.mode.value,
+            "operation_mode_sub_type": self.operation_mode_sub_type,
+            "reserved_soc": self.reserved_soc,
+            "very_low_soc": self.very_low_soc,
+            "charge_from_grid": self.charge_from_grid,
+            "date": self.date,
+        }

--- a/src/pyenphase/updaters/tariff.py
+++ b/src/pyenphase/updaters/tariff.py
@@ -1,0 +1,23 @@
+import logging
+
+from ..const import URL_TARIFF, SupportedFeatures
+from ..models.envoy import EnvoyData
+from ..models.tariff import EnvoyTariff
+from .base import EnvoyUpdater
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EnvoyTariffUpdater(EnvoyUpdater):
+    """Class to handle updates for the Envoy tariff data."""
+
+    async def probe(
+        self, discovered_features: SupportedFeatures
+    ) -> SupportedFeatures | None:
+        return discovered_features
+
+    async def update(self, envoy_data: EnvoyData) -> None:
+        raw = await self._json_request(URL_TARIFF)
+        envoy_data.raw[URL_TARIFF] = raw
+
+        envoy_data.tariff = EnvoyTariff.from_api(raw["tariff"])

--- a/tests/__snapshots__/test_endpoints.ambr
+++ b/tests/__snapshots__/test_endpoints.ambr
@@ -615,6 +615,26 @@
       }),
     }),
     'raw': dict({
+      '/admin/lib/tariff': dict({
+        'schedule': dict({
+          'date': '2023-08-10 17:59:03 UTC',
+          'source': 'Tariff',
+          'version': '00.00.02',
+        }),
+        'tariff': dict({
+          'currency': dict({
+            'code': 'USD',
+          }),
+          'seasons': list([
+          ]),
+          'seasons_sell': list([
+          ]),
+          'single_rate': dict({
+            'rate': 0.0,
+            'sell': 0.0,
+          }),
+        }),
+      }),
       '/api/v1/production': dict({
         'wattHoursLifetime': 133798553,
         'wattHoursSevenDays': 366671,
@@ -911,6 +931,22 @@
       'watt_hours_today': 20161,
       'watts_now': 7907,
     }),
+    'tariff': dict({
+      'currency': dict({
+        'code': 'USD',
+      }),
+      'date': None,
+      'logger': None,
+      'seasons': list([
+      ]),
+      'seasons_sell': list([
+      ]),
+      'single_rate': dict({
+        'rate': 0.0,
+        'sell': 0.0,
+      }),
+      'storage_settings': None,
+    }),
   })
 # ---
 # name: test_with_7_x_firmware[7.3.130]
@@ -1183,6 +1219,7 @@
       'watt_hours_today': 87,
       'watts_now': 180,
     }),
+    'tariff': None,
   })
 # ---
 # name: test_with_7_x_firmware[7.3.130_no_consumption]
@@ -1288,6 +1325,185 @@
       }),
     }),
     'raw': dict({
+      '/admin/lib/tariff': dict({
+        'schedule': dict({
+          'battery_mode': 'self-consumption',
+          'charge_from_grid': False,
+          'date': '2023-07-09 22:07:02 UTC',
+          'operation_mode_sub_type': '',
+          'override': False,
+          'override_backup_soc': 30.0,
+          'override_chg_dischg_rate': 0.0,
+          'override_tou_mode': 'StorageTouMode_DEFAULT_TOU_MODE',
+          'reserved_soc': 0.0,
+          'schedule': dict({
+            'Disable': list([
+              dict({
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+            ]),
+            'tariff': list([
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'end': '1/1',
+                'start': '1/1',
+              }),
+            ]),
+          }),
+          'source': 'Tariff',
+          'version': '00.00.02',
+          'very_low_soc': 5,
+        }),
+        'tariff': dict({
+          'currency': dict({
+            'code': 'USD',
+          }),
+          'date': '1680547193',
+          'logger': 'mylogger',
+          'seasons': list([
+            dict({
+              'days': list([
+              ]),
+              'id': 'season_1',
+              'start': '1/1',
+              'tiers': list([
+                dict({
+                  'id': 'tier_1',
+                  'limit': 1000,
+                  'rate': 0.15128,
+                }),
+                dict({
+                  'id': 'tier_2',
+                  'limit': -1,
+                  'rate': 0.1585,
+                }),
+              ]),
+            }),
+          ]),
+          'seasons_sell': list([
+          ]),
+          'single_rate': dict({
+            'rate': 0.15128,
+            'sell': 0.0,
+          }),
+          'storage_settings': dict({
+            'charge_from_grid': False,
+            'date': '1680547193',
+            'mode': 'self-consumption',
+            'operation_mode_sub_type': '',
+            'reserved_soc': 0.0,
+            'very_low_soc': 5,
+          }),
+        }),
+      }),
       '/api/v1/production/inverters': list([
         dict({
           'devType': 1,
@@ -1488,6 +1704,47 @@
       'watt_hours_lifetime': 4545928,
       'watt_hours_today': 14850,
       'watts_now': 3731,
+    }),
+    'tariff': dict({
+      'currency': dict({
+        'code': 'USD',
+      }),
+      'date': '1680547193',
+      'logger': 'mylogger',
+      'seasons': list([
+        dict({
+          'days': list([
+          ]),
+          'id': 'season_1',
+          'start': '1/1',
+          'tiers': list([
+            dict({
+              'id': 'tier_1',
+              'limit': 1000,
+              'rate': 0.15128,
+            }),
+            dict({
+              'id': 'tier_2',
+              'limit': -1,
+              'rate': 0.1585,
+            }),
+          ]),
+        }),
+      ]),
+      'seasons_sell': list([
+      ]),
+      'single_rate': dict({
+        'rate': 0.15128,
+        'sell': 0.0,
+      }),
+      'storage_settings': dict({
+        'charge_from_grid': False,
+        'date': '1680547193',
+        'mode': <EnvoyStorageMode.SELF_CONSUMPTION: 'self-consumption'>,
+        'operation_mode_sub_type': '',
+        'reserved_soc': 0.0,
+        'very_low_soc': 5,
+      }),
     }),
   })
 # ---
@@ -1843,6 +2100,167 @@
       }),
     }),
     'raw': dict({
+      '/admin/lib/tariff': dict({
+        'schedule': dict({
+          'battery_mode': 'backup',
+          'charge_from_grid': True,
+          'date': '2023-08-19 19:04:23 UTC',
+          'operation_mode_sub_type': '',
+          'override': False,
+          'override_backup_soc': 30.0,
+          'override_chg_dischg_rate': 0.0,
+          'override_tou_mode': 'StorageTouMode_DEFAULT_TOU_MODE',
+          'reserved_soc': 100.0,
+          'schedule': dict({
+            'Disable': list([
+              dict({
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+            ]),
+            'tariff': list([
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'CG',
+                    'start': 0,
+                  }),
+                ]),
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'CG',
+                    'start': 0,
+                  }),
+                ]),
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'CG',
+                    'start': 0,
+                  }),
+                ]),
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'CG',
+                    'start': 0,
+                  }),
+                ]),
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'CG',
+                    'start': 0,
+                  }),
+                ]),
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'CG',
+                    'start': 0,
+                  }),
+                ]),
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'CG',
+                    'start': 0,
+                  }),
+                ]),
+                'end': '1/1',
+                'start': '1/1',
+              }),
+            ]),
+          }),
+          'source': 'Tariff',
+          'version': '00.00.02',
+          'very_low_soc': 10,
+        }),
+        'tariff': dict({
+          'currency': dict({
+            'code': 'USD',
+          }),
+          'date': '1692471808',
+          'logger': 'mylogger',
+          'seasons': list([
+          ]),
+          'seasons_sell': list([
+          ]),
+          'single_rate': dict({
+            'rate': 0.0,
+            'sell': 0.0,
+          }),
+          'storage_settings': dict({
+            'charge_from_grid': True,
+            'date': '1692471808',
+            'mode': 'backup',
+            'operation_mode_sub_type': '',
+            'reserved_soc': 100.0,
+            'very_low_soc': 10,
+          }),
+        }),
+      }),
       '/api/v1/production/inverters': list([
         dict({
           'devType': 1,
@@ -2372,6 +2790,29 @@
       'watt_hours_today': 18635,
       'watts_now': 4300,
     }),
+    'tariff': dict({
+      'currency': dict({
+        'code': 'USD',
+      }),
+      'date': '1692471808',
+      'logger': 'mylogger',
+      'seasons': list([
+      ]),
+      'seasons_sell': list([
+      ]),
+      'single_rate': dict({
+        'rate': 0.0,
+        'sell': 0.0,
+      }),
+      'storage_settings': dict({
+        'charge_from_grid': True,
+        'date': '1692471808',
+        'mode': <EnvoyStorageMode.BACKUP: 'backup'>,
+        'operation_mode_sub_type': '',
+        'reserved_soc': 100.0,
+        'very_low_soc': 10,
+      }),
+    }),
   })
 # ---
 # name: test_with_7_x_firmware[7.3.517_no_black_start]
@@ -2672,6 +3113,412 @@
       }),
     }),
     'raw': dict({
+      '/admin/lib/tariff': dict({
+        'schedule': dict({
+          'battery_mode': 'self-consumption',
+          'charge_from_grid': False,
+          'date': '2023-08-31 06:04:08 UTC',
+          'operation_mode_sub_type': '',
+          'override': False,
+          'override_backup_soc': 30.0,
+          'override_chg_dischg_rate': 0.0,
+          'override_tou_mode': 'StorageTouMode_DEFAULT_TOU_MODE',
+          'reserved_soc': 20.0,
+          'schedule': dict({
+            'Disable': list([
+              dict({
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+            ]),
+            'tariff': list([
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'end': '10/1',
+                'start': '6/1',
+              }),
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'end': '6/1',
+                'start': '10/1',
+              }),
+            ]),
+          }),
+          'source': 'Tariff',
+          'version': '00.00.02',
+          'very_low_soc': 10,
+        }),
+        'tariff': dict({
+          'currency': dict({
+            'code': 'USD',
+          }),
+          'date': '1693461802',
+          'logger': 'mylogger',
+          'seasons': list([
+            dict({
+              'days': list([
+                dict({
+                  'days': 'Mon,Tue,Wed,Thu,Fri',
+                  'enable_discharge_to_grid': False,
+                  'id': 'weekdays',
+                  'must_charge_duration': 0,
+                  'must_charge_mode': 'CP',
+                  'must_charge_start': 0,
+                  'periods': list([
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.183109,
+                      'start': 0,
+                    }),
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.24488,
+                      'start': 1020,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.183109,
+                      'start': 1200,
+                    }),
+                  ]),
+                }),
+                dict({
+                  'days': 'Sat,Sun',
+                  'enable_discharge_to_grid': False,
+                  'id': 'weekend',
+                  'must_charge_duration': 0,
+                  'must_charge_mode': 'CP',
+                  'must_charge_start': 0,
+                  'periods': list([
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.183109,
+                      'start': 0,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.0,
+                      'start': 1439,
+                    }),
+                  ]),
+                }),
+              ]),
+              'id': 'summer',
+              'start': '6/1',
+              'tiers': list([
+              ]),
+            }),
+            dict({
+              'days': list([
+                dict({
+                  'days': 'Mon,Tue,Wed,Thu,Fri',
+                  'enable_discharge_to_grid': False,
+                  'id': 'weekdays',
+                  'must_charge_duration': 0,
+                  'must_charge_mode': 'CP',
+                  'must_charge_start': 0,
+                  'periods': list([
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.185529,
+                      'start': 0,
+                    }),
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.196829,
+                      'start': 1020,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.185529,
+                      'start': 1200,
+                    }),
+                  ]),
+                }),
+                dict({
+                  'days': 'Sat,Sun',
+                  'enable_discharge_to_grid': False,
+                  'id': 'weekend',
+                  'must_charge_duration': 0,
+                  'must_charge_mode': 'CP',
+                  'must_charge_start': 0,
+                  'periods': list([
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.185529,
+                      'start': 0,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.0,
+                      'start': 1439,
+                    }),
+                  ]),
+                }),
+              ]),
+              'id': 'winter',
+              'start': '10/1',
+              'tiers': list([
+              ]),
+            }),
+          ]),
+          'seasons_sell': list([
+            dict({
+              'days': list([
+                dict({
+                  'days': 'Mon,Tue,Wed,Thu,Fri',
+                  'id': 'weekdays',
+                  'periods': list([
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.183109,
+                      'start': 0,
+                    }),
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.24488,
+                      'start': 1020,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.183109,
+                      'start': 1200,
+                    }),
+                  ]),
+                }),
+                dict({
+                  'days': 'Sat,Sun',
+                  'id': 'weekend',
+                  'periods': list([
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.183109,
+                      'start': 0,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.0,
+                      'start': 1439,
+                    }),
+                  ]),
+                }),
+              ]),
+              'id': 'summer',
+              'start': '6/1',
+            }),
+            dict({
+              'days': list([
+                dict({
+                  'days': 'Mon,Tue,Wed,Thu,Fri',
+                  'id': 'weekdays',
+                  'periods': list([
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.185529,
+                      'start': 0,
+                    }),
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.196829,
+                      'start': 1020,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.185529,
+                      'start': 1200,
+                    }),
+                  ]),
+                }),
+                dict({
+                  'days': 'Sat,Sun',
+                  'id': 'weekend',
+                  'periods': list([
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.185529,
+                      'start': 0,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.0,
+                      'start': 1439,
+                    }),
+                  ]),
+                }),
+              ]),
+              'id': 'winter',
+              'start': '10/1',
+            }),
+          ]),
+          'single_rate': dict({
+            'rate': 0.183109,
+            'sell': 0.183109,
+          }),
+          'storage_settings': dict({
+            'charge_from_grid': False,
+            'date': '1693461802',
+            'mode': 'self-consumption',
+            'operation_mode_sub_type': '',
+            'reserved_soc': 20.0,
+            'very_low_soc': 10,
+          }),
+        }),
+      }),
       '/api/v1/production/inverters': list([
         dict({
           'devType': 1,
@@ -3118,6 +3965,221 @@
       'watt_hours_today': 11495,
       'watts_now': 2663,
     }),
+    'tariff': dict({
+      'currency': dict({
+        'code': 'USD',
+      }),
+      'date': '1693461802',
+      'logger': 'mylogger',
+      'seasons': list([
+        dict({
+          'days': list([
+            dict({
+              'days': 'Mon,Tue,Wed,Thu,Fri',
+              'enable_discharge_to_grid': False,
+              'id': 'weekdays',
+              'must_charge_duration': 0,
+              'must_charge_mode': 'CP',
+              'must_charge_start': 0,
+              'periods': list([
+                dict({
+                  'id': 'filler',
+                  'rate': 0.183109,
+                  'start': 0,
+                }),
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.24488,
+                  'start': 1020,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.183109,
+                  'start': 1200,
+                }),
+              ]),
+            }),
+            dict({
+              'days': 'Sat,Sun',
+              'enable_discharge_to_grid': False,
+              'id': 'weekend',
+              'must_charge_duration': 0,
+              'must_charge_mode': 'CP',
+              'must_charge_start': 0,
+              'periods': list([
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.183109,
+                  'start': 0,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.0,
+                  'start': 1439,
+                }),
+              ]),
+            }),
+          ]),
+          'id': 'summer',
+          'start': '6/1',
+          'tiers': list([
+          ]),
+        }),
+        dict({
+          'days': list([
+            dict({
+              'days': 'Mon,Tue,Wed,Thu,Fri',
+              'enable_discharge_to_grid': False,
+              'id': 'weekdays',
+              'must_charge_duration': 0,
+              'must_charge_mode': 'CP',
+              'must_charge_start': 0,
+              'periods': list([
+                dict({
+                  'id': 'filler',
+                  'rate': 0.185529,
+                  'start': 0,
+                }),
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.196829,
+                  'start': 1020,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.185529,
+                  'start': 1200,
+                }),
+              ]),
+            }),
+            dict({
+              'days': 'Sat,Sun',
+              'enable_discharge_to_grid': False,
+              'id': 'weekend',
+              'must_charge_duration': 0,
+              'must_charge_mode': 'CP',
+              'must_charge_start': 0,
+              'periods': list([
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.185529,
+                  'start': 0,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.0,
+                  'start': 1439,
+                }),
+              ]),
+            }),
+          ]),
+          'id': 'winter',
+          'start': '10/1',
+          'tiers': list([
+          ]),
+        }),
+      ]),
+      'seasons_sell': list([
+        dict({
+          'days': list([
+            dict({
+              'days': 'Mon,Tue,Wed,Thu,Fri',
+              'id': 'weekdays',
+              'periods': list([
+                dict({
+                  'id': 'filler',
+                  'rate': 0.183109,
+                  'start': 0,
+                }),
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.24488,
+                  'start': 1020,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.183109,
+                  'start': 1200,
+                }),
+              ]),
+            }),
+            dict({
+              'days': 'Sat,Sun',
+              'id': 'weekend',
+              'periods': list([
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.183109,
+                  'start': 0,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.0,
+                  'start': 1439,
+                }),
+              ]),
+            }),
+          ]),
+          'id': 'summer',
+          'start': '6/1',
+        }),
+        dict({
+          'days': list([
+            dict({
+              'days': 'Mon,Tue,Wed,Thu,Fri',
+              'id': 'weekdays',
+              'periods': list([
+                dict({
+                  'id': 'filler',
+                  'rate': 0.185529,
+                  'start': 0,
+                }),
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.196829,
+                  'start': 1020,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.185529,
+                  'start': 1200,
+                }),
+              ]),
+            }),
+            dict({
+              'days': 'Sat,Sun',
+              'id': 'weekend',
+              'periods': list([
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.185529,
+                  'start': 0,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.0,
+                  'start': 1439,
+                }),
+              ]),
+            }),
+          ]),
+          'id': 'winter',
+          'start': '10/1',
+        }),
+      ]),
+      'single_rate': dict({
+        'rate': 0.183109,
+        'sell': 0.183109,
+      }),
+      'storage_settings': dict({
+        'charge_from_grid': False,
+        'date': '1693461802',
+        'mode': <EnvoyStorageMode.SELF_CONSUMPTION: 'self-consumption'>,
+        'operation_mode_sub_type': '',
+        'reserved_soc': 20.0,
+        'very_low_soc': 10,
+      }),
+    }),
   })
 # ---
 # name: test_with_7_x_firmware[7.6.114_without_cts]
@@ -3318,6 +4380,7 @@
       'watt_hours_today': 10363,
       'watts_now': 586,
     }),
+    'tariff': None,
   })
 # ---
 # name: test_with_7_x_firmware[7.6.175]
@@ -3518,6 +4581,7 @@
       'watt_hours_today': 7883,
       'watts_now': 3391,
     }),
+    'tariff': None,
   })
 # ---
 # name: test_with_7_x_firmware[7.6.175_standard]
@@ -3861,6 +4925,7 @@
       'watt_hours_today': 36462,
       'watts_now': 5740,
     }),
+    'tariff': None,
   })
 # ---
 # name: test_with_7_x_firmware[7.6.175_total]
@@ -3960,6 +5025,200 @@
       }),
     }),
     'raw': dict({
+      '/admin/lib/tariff': dict({
+        'schedule': dict({
+          'battery_mode': 'self-consumption',
+          'charge_from_grid': False,
+          'date': '2023-07-06 06:11:26 UTC',
+          'operation_mode_sub_type': '',
+          'override': False,
+          'override_backup_soc': 30.0,
+          'override_chg_dischg_rate': 0.0,
+          'override_tou_mode': 'StorageTouMode_DEFAULT_TOU_MODE',
+          'reserved_soc': 30.0,
+          'schedule': dict({
+            'Disable': list([
+              dict({
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+            ]),
+            'tariff': list([
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'end': '1/1',
+                'start': '1/1',
+              }),
+            ]),
+          }),
+          'source': 'Tariff',
+          'version': '00.00.02',
+          'very_low_soc': 10,
+        }),
+        'tariff': dict({
+          'currency': dict({
+            'code': 'EUR',
+          }),
+          'date': '1688623885',
+          'logger': 'mylogger',
+          'seasons': list([
+            dict({
+              'days': list([
+                dict({
+                  'days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+                  'enable_discharge_to_grid': False,
+                  'id': 'all_days',
+                  'must_charge_duration': 0,
+                  'must_charge_mode': 'CG',
+                  'must_charge_start': 0,
+                  'periods': list([
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.38914,
+                      'start': 0,
+                    }),
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.4424,
+                      'start': 420,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.38914,
+                      'start': 1381,
+                    }),
+                  ]),
+                }),
+              ]),
+              'id': 'all_year_long',
+              'start': '1/1',
+              'tiers': list([
+              ]),
+            }),
+          ]),
+          'seasons_sell': list([
+          ]),
+          'single_rate': dict({
+            'rate': 0.38914,
+            'sell': 0.0,
+          }),
+          'storage_settings': dict({
+            'charge_from_grid': False,
+            'date': '1688623885',
+            'mode': 'self-consumption',
+            'operation_mode_sub_type': '',
+            'reserved_soc': 30.0,
+            'very_low_soc': 10,
+          }),
+        }),
+      }),
       '/api/v1/production/inverters': list([
         dict({
           'devType': 1,
@@ -4154,6 +5413,62 @@
       'watt_hours_today': 0,
       'watts_now': 1322,
     }),
+    'tariff': dict({
+      'currency': dict({
+        'code': 'EUR',
+      }),
+      'date': '1688623885',
+      'logger': 'mylogger',
+      'seasons': list([
+        dict({
+          'days': list([
+            dict({
+              'days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+              'enable_discharge_to_grid': False,
+              'id': 'all_days',
+              'must_charge_duration': 0,
+              'must_charge_mode': 'CG',
+              'must_charge_start': 0,
+              'periods': list([
+                dict({
+                  'id': 'filler',
+                  'rate': 0.38914,
+                  'start': 0,
+                }),
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.4424,
+                  'start': 420,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.38914,
+                  'start': 1381,
+                }),
+              ]),
+            }),
+          ]),
+          'id': 'all_year_long',
+          'start': '1/1',
+          'tiers': list([
+          ]),
+        }),
+      ]),
+      'seasons_sell': list([
+      ]),
+      'single_rate': dict({
+        'rate': 0.38914,
+        'sell': 0.0,
+      }),
+      'storage_settings': dict({
+        'charge_from_grid': False,
+        'date': '1688623885',
+        'mode': <EnvoyStorageMode.SELF_CONSUMPTION: 'self-consumption'>,
+        'operation_mode_sub_type': '',
+        'reserved_soc': 30.0,
+        'very_low_soc': 10,
+      }),
+    }),
   })
 # ---
 # name: test_with_7_x_firmware[7.6.175_with_cts]
@@ -4211,6 +5526,195 @@
       }),
     }),
     'raw': dict({
+      '/admin/lib/tariff': dict({
+        'schedule': dict({
+          'battery_mode': 'self-consumption',
+          'charge_from_grid': False,
+          'date': '2023-06-29 15:50:12 UTC',
+          'operation_mode_sub_type': '',
+          'override': False,
+          'override_backup_soc': 30.0,
+          'override_chg_dischg_rate': 0.0,
+          'override_tou_mode': 'StorageTouMode_DEFAULT_TOU_MODE',
+          'reserved_soc': 0.0,
+          'schedule': dict({
+            'Disable': list([
+              dict({
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+            ]),
+            'tariff': list([
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                ]),
+                'end': '1/1',
+                'start': '1/1',
+              }),
+            ]),
+          }),
+          'source': 'Tariff',
+          'version': '00.00.02',
+          'very_low_soc': 5,
+        }),
+        'tariff': dict({
+          'currency': dict({
+            'code': 'EUR',
+          }),
+          'date': '1688053811',
+          'logger': 'mylogger',
+          'seasons': list([
+            dict({
+              'days': list([
+                dict({
+                  'days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+                  'enable_discharge_to_grid': False,
+                  'id': 'all_days',
+                  'must_charge_duration': 0,
+                  'must_charge_mode': 'CG',
+                  'must_charge_start': 0,
+                  'periods': list([
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.14,
+                      'start': 480,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.01,
+                      'start': 1320,
+                    }),
+                  ]),
+                }),
+              ]),
+              'id': 'all_year_long',
+              'start': '1/1',
+              'tiers': list([
+              ]),
+            }),
+          ]),
+          'seasons_sell': list([
+          ]),
+          'single_rate': dict({
+            'rate': 0.01,
+            'sell': 0.0,
+          }),
+          'storage_settings': dict({
+            'charge_from_grid': False,
+            'date': '1688053811',
+            'mode': 'self-consumption',
+            'operation_mode_sub_type': '',
+            'reserved_soc': 0.0,
+            'very_low_soc': 5,
+          }),
+        }),
+      }),
       '/api/v1/production/inverters': list([
         dict({
           'devType': 1,
@@ -4360,6 +5864,57 @@
       'watt_hours_lifetime': 3183793,
       'watt_hours_today': 4425,
       'watts_now': 488,
+    }),
+    'tariff': dict({
+      'currency': dict({
+        'code': 'EUR',
+      }),
+      'date': '1688053811',
+      'logger': 'mylogger',
+      'seasons': list([
+        dict({
+          'days': list([
+            dict({
+              'days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+              'enable_discharge_to_grid': False,
+              'id': 'all_days',
+              'must_charge_duration': 0,
+              'must_charge_mode': 'CG',
+              'must_charge_start': 0,
+              'periods': list([
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.14,
+                  'start': 480,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.01,
+                  'start': 1320,
+                }),
+              ]),
+            }),
+          ]),
+          'id': 'all_year_long',
+          'start': '1/1',
+          'tiers': list([
+          ]),
+        }),
+      ]),
+      'seasons_sell': list([
+      ]),
+      'single_rate': dict({
+        'rate': 0.01,
+        'sell': 0.0,
+      }),
+      'storage_settings': dict({
+        'charge_from_grid': False,
+        'date': '1688053811',
+        'mode': <EnvoyStorageMode.SELF_CONSUMPTION: 'self-consumption'>,
+        'operation_mode_sub_type': '',
+        'reserved_soc': 0.0,
+        'very_low_soc': 5,
+      }),
     }),
   })
 # ---
@@ -5760,5 +7315,6 @@
       'watt_hours_today': 55045,
       'watts_now': 13028,
     }),
+    'tariff': None,
   })
 # ---

--- a/tests/__snapshots__/test_endpoints.ambr
+++ b/tests/__snapshots__/test_endpoints.ambr
@@ -126,6 +126,46 @@
       }),
     }),
     'raw': dict({
+      '/admin/lib/tariff': dict({
+        'schedule': dict({
+          'date': '2023-05-11 19:46:56 UTC',
+          'source': 'Tariff',
+          'version': '00.00.01',
+        }),
+        'tariff': dict({
+          'currency': dict({
+            'code': 'USD',
+          }),
+          'seasons': list([
+            dict({
+              'days': list([
+              ]),
+              'id': 'season_1',
+              'start': '1/1',
+              'tiers': list([
+                dict({
+                  'id': 'tier_1',
+                  'limit': 500,
+                  'rate': 0.21835,
+                }),
+                dict({
+                  'id': 'tier_2',
+                  'limit': 1200,
+                  'rate': 0.19587,
+                }),
+                dict({
+                  'id': 'tier_3',
+                  'limit': -1,
+                  'rate': 0.15798,
+                }),
+              ]),
+            }),
+          ]),
+          'single_rate': dict({
+            'rate': 0.21835,
+          }),
+        }),
+      }),
       '/api/v1/production/inverters': list([
         dict({
           'devType': 1,
@@ -359,6 +399,43 @@
       'watt_hours_lifetime': 26785327,
       'watt_hours_today': 139,
       'watts_now': 166,
+    }),
+    'tariff': dict({
+      'currency': dict({
+        'code': 'USD',
+      }),
+      'date': None,
+      'logger': None,
+      'seasons': list([
+        dict({
+          'days': list([
+          ]),
+          'id': 'season_1',
+          'start': '1/1',
+          'tiers': list([
+            dict({
+              'id': 'tier_1',
+              'limit': 500,
+              'rate': 0.21835,
+            }),
+            dict({
+              'id': 'tier_2',
+              'limit': 1200,
+              'rate': 0.19587,
+            }),
+            dict({
+              'id': 'tier_3',
+              'limit': -1,
+              'rate': 0.15798,
+            }),
+          ]),
+        }),
+      ]),
+      'seasons_sell': None,
+      'single_rate': dict({
+        'rate': 0.21835,
+      }),
+      'storage_settings': None,
     }),
   })
 # ---
@@ -5999,6 +6076,265 @@
       }),
     }),
     'raw': dict({
+      '/admin/lib/tariff': dict({
+        'schedule': dict({
+          'battery_mode': 'self-consumption',
+          'charge_from_grid': True,
+          'date': '2023-09-26 16:03:40 UTC',
+          'operation_mode_sub_type': '',
+          'override': False,
+          'override_backup_soc': 30.0,
+          'override_chg_dischg_rate': 0.0,
+          'override_tou_mode': 'StorageTouMode_DEFAULT_TOU_MODE',
+          'reserved_soc': 15.0,
+          'schedule': dict({
+            'Disable': list([
+              dict({
+                'Sun': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Mon': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Tue': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Wed': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Thu': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+              dict({
+                'Sat': list([
+                  dict({
+                    'duration': 1440,
+                    'setting': 'ID',
+                    'start': 0,
+                  }),
+                ]),
+              }),
+            ]),
+            'tariff': list([
+              dict({
+                'Fri': list([
+                  dict({
+                    'duration': 444,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                  dict({
+                    'duration': 35,
+                    'setting': 'CG',
+                    'start': 444,
+                  }),
+                  dict({
+                    'duration': 961,
+                    'setting': 'ZN',
+                    'start': 479,
+                  }),
+                ]),
+                'Mon': list([
+                  dict({
+                    'duration': 444,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                  dict({
+                    'duration': 35,
+                    'setting': 'CG',
+                    'start': 444,
+                  }),
+                  dict({
+                    'duration': 961,
+                    'setting': 'ZN',
+                    'start': 479,
+                  }),
+                ]),
+                'Sat': list([
+                  dict({
+                    'duration': 444,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                  dict({
+                    'duration': 35,
+                    'setting': 'CG',
+                    'start': 444,
+                  }),
+                  dict({
+                    'duration': 961,
+                    'setting': 'ZN',
+                    'start': 479,
+                  }),
+                ]),
+                'Sun': list([
+                  dict({
+                    'duration': 444,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                  dict({
+                    'duration': 35,
+                    'setting': 'CG',
+                    'start': 444,
+                  }),
+                  dict({
+                    'duration': 961,
+                    'setting': 'ZN',
+                    'start': 479,
+                  }),
+                ]),
+                'Thu': list([
+                  dict({
+                    'duration': 444,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                  dict({
+                    'duration': 35,
+                    'setting': 'CG',
+                    'start': 444,
+                  }),
+                  dict({
+                    'duration': 961,
+                    'setting': 'ZN',
+                    'start': 479,
+                  }),
+                ]),
+                'Tue': list([
+                  dict({
+                    'duration': 444,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                  dict({
+                    'duration': 35,
+                    'setting': 'CG',
+                    'start': 444,
+                  }),
+                  dict({
+                    'duration': 961,
+                    'setting': 'ZN',
+                    'start': 479,
+                  }),
+                ]),
+                'Wed': list([
+                  dict({
+                    'duration': 444,
+                    'setting': 'ZN',
+                    'start': 0,
+                  }),
+                  dict({
+                    'duration': 35,
+                    'setting': 'CG',
+                    'start': 444,
+                  }),
+                  dict({
+                    'duration': 961,
+                    'setting': 'ZN',
+                    'start': 479,
+                  }),
+                ]),
+                'end': '1/1',
+                'start': '1/1',
+              }),
+            ]),
+          }),
+          'source': 'Tariff',
+          'version': '00.00.02',
+          'very_low_soc': 5,
+        }),
+        'tariff': dict({
+          'currency': dict({
+            'code': 'EUR',
+          }),
+          'date': '1695744220',
+          'logger': 'mylogger',
+          'seasons': list([
+            dict({
+              'days': list([
+                dict({
+                  'days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+                  'enable_discharge_to_grid': True,
+                  'id': 'all_days',
+                  'must_charge_duration': 35,
+                  'must_charge_mode': 'CG',
+                  'must_charge_start': 444,
+                  'periods': list([
+                    dict({
+                      'id': 'period_1',
+                      'rate': 0.1898,
+                      'start': 480,
+                    }),
+                    dict({
+                      'id': 'filler',
+                      'rate': 0.1034,
+                      'start': 1320,
+                    }),
+                  ]),
+                }),
+              ]),
+              'id': 'season_1',
+              'start': '1/1',
+              'tiers': list([
+              ]),
+            }),
+          ]),
+          'seasons_sell': list([
+          ]),
+          'single_rate': dict({
+            'rate': 0.0,
+            'sell': 0.0,
+          }),
+          'storage_settings': dict({
+            'charge_from_grid': True,
+            'date': '1695598084',
+            'mode': 'self-consumption',
+            'operation_mode_sub_type': '',
+            'reserved_soc': 15.0,
+            'very_low_soc': 5,
+          }),
+        }),
+      }),
       '/api/v1/production/inverters': list([
         dict({
           'devType': 1,
@@ -6207,6 +6543,57 @@
       'watt_hours_lifetime': 2432970,
       'watt_hours_today': 1,
       'watts_now': 0,
+    }),
+    'tariff': dict({
+      'currency': dict({
+        'code': 'EUR',
+      }),
+      'date': '1695744220',
+      'logger': 'mylogger',
+      'seasons': list([
+        dict({
+          'days': list([
+            dict({
+              'days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+              'enable_discharge_to_grid': True,
+              'id': 'all_days',
+              'must_charge_duration': 35,
+              'must_charge_mode': 'CG',
+              'must_charge_start': 444,
+              'periods': list([
+                dict({
+                  'id': 'period_1',
+                  'rate': 0.1898,
+                  'start': 480,
+                }),
+                dict({
+                  'id': 'filler',
+                  'rate': 0.1034,
+                  'start': 1320,
+                }),
+              ]),
+            }),
+          ]),
+          'id': 'season_1',
+          'start': '1/1',
+          'tiers': list([
+          ]),
+        }),
+      ]),
+      'seasons_sell': list([
+      ]),
+      'single_rate': dict({
+        'rate': 0.0,
+        'sell': 0.0,
+      }),
+      'storage_settings': dict({
+        'charge_from_grid': True,
+        'date': '1695598084',
+        'mode': <EnvoyStorageMode.SELF_CONSUMPTION: 'self-consumption'>,
+        'operation_mode_sub_type': '',
+        'reserved_soc': 15.0,
+        'very_low_soc': 5,
+      }),
     }),
   })
 # ---

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1168,13 +1168,15 @@ async def test_with_3_17_3_firmware():
             | SupportedFeatures.INVERTERS
             | SupportedFeatures.TOTAL_CONSUMPTION
             | SupportedFeatures.NET_CONSUMPTION
-            | SupportedFeatures.PRODUCTION,
+            | SupportedFeatures.PRODUCTION
+            | SupportedFeatures.TARIFF,
             {
                 "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
                 "EnvoyProductionJsonUpdater": SupportedFeatures.METERING
                 | SupportedFeatures.TOTAL_CONSUMPTION
                 | SupportedFeatures.NET_CONSUMPTION
                 | SupportedFeatures.PRODUCTION,
+                "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
             },
         ),
         (
@@ -1316,7 +1318,8 @@ async def test_with_3_17_3_firmware():
             | SupportedFeatures.TOTAL_CONSUMPTION
             | SupportedFeatures.NET_CONSUMPTION
             | SupportedFeatures.PRODUCTION
-            | SupportedFeatures.ENCHARGE,
+            | SupportedFeatures.ENCHARGE
+            | SupportedFeatures.TARIFF,
             {
                 "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
                 "EnvoyEnembleUpdater": SupportedFeatures.ENCHARGE,
@@ -1324,6 +1327,7 @@ async def test_with_3_17_3_firmware():
                 | SupportedFeatures.TOTAL_CONSUMPTION
                 | SupportedFeatures.NET_CONSUMPTION
                 | SupportedFeatures.PRODUCTION,
+                "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
             },
         ),
         (

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -77,6 +77,18 @@ async def test_with_4_2_27_firmware():
         )
     )
     respx.get("/api/v1/production/inverters").mock(return_value=Response(404))
+
+    path = f"tests/fixtures/{version}"
+    files = [f for f in listdir(path) if isfile(join(path, f))]
+    if "admin_lib_tariff" in files:
+        try:
+            json_data = _load_json_fixture(version, "admin_lib_tariff")
+        except json.decoder.JSONDecodeError:
+            json_data = None
+        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
+
     envoy = await _get_mock_envoy()
     data = envoy.data
     assert data is not None
@@ -129,6 +141,17 @@ async def test_with_5_0_49_firmware():
         )
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+
+    path = f"tests/fixtures/{version}"
+    files = [f for f in listdir(path) if isfile(join(path, f))]
+    if "admin_lib_tariff" in files:
+        try:
+            json_data = _load_json_fixture(version, "admin_lib_tariff")
+        except json.decoder.JSONDecodeError:
+            json_data = None
+        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
 
     envoy = await _get_mock_envoy()
     data = envoy.data
@@ -416,6 +439,7 @@ async def test_with_3_7_0_firmware():
         )
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
 
     # Verify the library does not support scraping to comply with ADR004
     with pytest.raises(EnvoyProbeFailed):
@@ -533,6 +557,17 @@ async def test_with_3_9_36_firmware_bad_auth():
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
 
+    path = f"tests/fixtures/{version}"
+    files = [f for f in listdir(path) if isfile(join(path, f))]
+    if "admin_lib_tariff" in files:
+        try:
+            json_data = _load_json_fixture(version, "admin_lib_tariff")
+        except json.decoder.JSONDecodeError:
+            json_data = None
+        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
+
     with pytest.raises(EnvoyAuthenticationRequired):
         await _get_mock_envoy()
 
@@ -559,6 +594,17 @@ async def test_with_3_9_36_firmware_no_inverters():
         )
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+
+    path = f"tests/fixtures/{version}"
+    files = [f for f in listdir(path) if isfile(join(path, f))]
+    if "admin_lib_tariff" in files:
+        try:
+            json_data = _load_json_fixture(version, "admin_lib_tariff")
+        except json.decoder.JSONDecodeError:
+            json_data = None
+        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
 
     envoy = await _get_mock_envoy()
     data = envoy.data
@@ -595,6 +641,17 @@ async def test_with_3_9_36_firmware():
         )
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+
+    path = f"tests/fixtures/{version}"
+    files = [f for f in listdir(path) if isfile(join(path, f))]
+    if "admin_lib_tariff" in files:
+        try:
+            json_data = _load_json_fixture(version, "admin_lib_tariff")
+        except json.decoder.JSONDecodeError:
+            json_data = None
+        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
 
     envoy = await _get_mock_envoy()
     data = envoy.data
@@ -713,6 +770,17 @@ async def test_with_3_9_36_firmware_with_production_401():
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
 
+    path = f"tests/fixtures/{version}"
+    files = [f for f in listdir(path) if isfile(join(path, f))]
+    if "admin_lib_tariff" in files:
+        try:
+            json_data = _load_json_fixture(version, "admin_lib_tariff")
+        except json.decoder.JSONDecodeError:
+            json_data = None
+        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
+
     envoy = await _get_mock_envoy()
     data = envoy.data
     assert data is not None
@@ -756,6 +824,16 @@ async def test_with_3_9_36_firmware_with_production_and_production_json_401():
         )
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+    path = f"tests/fixtures/{version}"
+    files = [f for f in listdir(path) if isfile(join(path, f))]
+    if "admin_lib_tariff" in files:
+        try:
+            json_data = _load_json_fixture(version, "admin_lib_tariff")
+        except json.decoder.JSONDecodeError:
+            json_data = None
+        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
 
     with pytest.raises(EnvoyAuthenticationRequired):
         await _get_mock_envoy()
@@ -783,6 +861,17 @@ async def test_with_3_17_3_firmware():
         )
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+
+    path = f"tests/fixtures/{version}"
+    files = [f for f in listdir(path) if isfile(join(path, f))]
+    if "admin_lib_tariff" in files:
+        try:
+            json_data = _load_json_fixture(version, "admin_lib_tariff")
+        except json.decoder.JSONDecodeError:
+            json_data = None
+        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
 
     envoy = await _get_mock_envoy()
     data = envoy.data
@@ -1063,10 +1152,13 @@ async def test_with_3_17_3_firmware():
         (
             "5.0.62",
             "800-00551-r02",
-            SupportedFeatures.INVERTERS | SupportedFeatures.PRODUCTION,
+            SupportedFeatures.INVERTERS
+            | SupportedFeatures.PRODUCTION
+            | SupportedFeatures.TARIFF,
             {
                 "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
                 "EnvoyApiV1ProductionUpdater": SupportedFeatures.PRODUCTION,
+                "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
             },
         ),
         (
@@ -1106,11 +1198,13 @@ async def test_with_3_17_3_firmware():
             "800-00647-r10",
             SupportedFeatures.METERING
             | SupportedFeatures.INVERTERS
-            | SupportedFeatures.PRODUCTION,
+            | SupportedFeatures.PRODUCTION
+            | SupportedFeatures.TARIFF,
             {
                 "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
                 "EnvoyProductionUpdater": SupportedFeatures.METERING
                 | SupportedFeatures.PRODUCTION,
+                "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
             },
         ),
         (
@@ -1122,7 +1216,8 @@ async def test_with_3_17_3_firmware():
             | SupportedFeatures.ENPOWER
             | SupportedFeatures.ENCHARGE
             | SupportedFeatures.INVERTERS
-            | SupportedFeatures.PRODUCTION,
+            | SupportedFeatures.PRODUCTION
+            | SupportedFeatures.TARIFF,
             {
                 "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
                 "EnvoyProductionUpdater": SupportedFeatures.METERING
@@ -1131,6 +1226,7 @@ async def test_with_3_17_3_firmware():
                 | SupportedFeatures.PRODUCTION,
                 "EnvoyEnembleUpdater": SupportedFeatures.ENPOWER
                 | SupportedFeatures.ENCHARGE,
+                "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
             },
         ),
         (
@@ -1142,7 +1238,8 @@ async def test_with_3_17_3_firmware():
             | SupportedFeatures.ENPOWER
             | SupportedFeatures.ENCHARGE
             | SupportedFeatures.INVERTERS
-            | SupportedFeatures.PRODUCTION,
+            | SupportedFeatures.PRODUCTION
+            | SupportedFeatures.TARIFF,
             {
                 "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
                 "EnvoyProductionUpdater": SupportedFeatures.METERING
@@ -1151,6 +1248,7 @@ async def test_with_3_17_3_firmware():
                 | SupportedFeatures.PRODUCTION,
                 "EnvoyEnembleUpdater": SupportedFeatures.ENPOWER
                 | SupportedFeatures.ENCHARGE,
+                "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
             },
         ),
         (
@@ -1174,10 +1272,13 @@ async def test_with_3_17_3_firmware():
         (
             "7.6.175_total",
             "800-00654-r06",
-            SupportedFeatures.INVERTERS | SupportedFeatures.PRODUCTION,
+            SupportedFeatures.INVERTERS
+            | SupportedFeatures.PRODUCTION
+            | SupportedFeatures.TARIFF,
             {
                 "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
                 "EnvoyProductionJsonFallbackUpdater": SupportedFeatures.PRODUCTION,
+                "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
             },
         ),
         (
@@ -1196,13 +1297,15 @@ async def test_with_3_17_3_firmware():
             | SupportedFeatures.METERING
             | SupportedFeatures.TOTAL_CONSUMPTION
             | SupportedFeatures.NET_CONSUMPTION
-            | SupportedFeatures.PRODUCTION,
+            | SupportedFeatures.PRODUCTION
+            | SupportedFeatures.TARIFF,
             {
                 "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
                 "EnvoyProductionUpdater": SupportedFeatures.METERING
                 | SupportedFeatures.TOTAL_CONSUMPTION
                 | SupportedFeatures.NET_CONSUMPTION
                 | SupportedFeatures.PRODUCTION,
+                "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
             },
         ),
         (
@@ -1364,6 +1467,15 @@ async def test_with_7_x_firmware(
         respx.get("/ivp/ensemble/secctrl").mock(
             return_value=Response(200, json=json_data)
         )
+
+    if "admin_lib_tariff" in files:
+        try:
+            json_data = _load_json_fixture(version, "admin_lib_tariff")
+        except json.decoder.JSONDecodeError:
+            json_data = None
+        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
 
     caplog.set_level(logging.DEBUG)
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1565,7 +1565,7 @@ async def test_with_7_x_firmware(
 
         await envoy.disable_charge_from_grid()
         assert envoy.data.tariff.storage_settings.charge_from_grid is False
-        assert respx.calls.last.request.content == orjson.dumps(
+        assert respx.calls.last.request.content == orjson.dumps(  # type: ignore[unreachable]
             {"tariff": envoy.data.tariff.to_api()}
         )
     else:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1572,6 +1572,18 @@ async def test_with_7_x_firmware(
         assert respx.calls.last.request.content == orjson.dumps(  # type: ignore[unreachable]
             {"tariff": envoy.data.tariff.to_api()}
         )
+
+        bad_envoy = await _get_mock_envoy()
+        await bad_envoy.probe()
+        with pytest.raises(EnvoyFeatureNotAvailable):
+            bad_envoy.data.tariff.storage_settings = None
+            await bad_envoy.enable_charge_from_grid()
+        with pytest.raises(ValueError):
+            bad_envoy.data.tariff = None
+            await bad_envoy.enable_charge_from_grid()
+        with pytest.raises(ValueError):
+            bad_envoy.data = None
+            await bad_envoy.enable_charge_from_grid()
     else:
         with pytest.raises(EnvoyFeatureNotAvailable):
             await envoy.enable_charge_from_grid()


### PR DESCRIPTION
Adds initial models for tariff data from `/admin/lib/tariff` and adds functions to enable and disable charging the Enphase batteries from grid power.

Unlike other API endpoints, the `/admin/lib/tariff` endpoint requires an HTTP PUT instead of an HTTP POST

Still need to update tests.