### PR TITLE
feat: Add support for changing storage mode and reserve soc

### DIFF
--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -31,6 +31,7 @@ from .exceptions import (
 from .firmware import EnvoyFirmware
 from .json import json_loads
 from .models.envoy import EnvoyData
+from .models.tariff import EnvoyStorageMode
 from .ssl import NO_VERIFY_SSL_CONTEXT
 from .updaters.api_v1_production import EnvoyApiV1ProductionUpdater
 from .updaters.api_v1_production_inverters import EnvoyApiV1ProductionInvertersUpdater
@@ -404,6 +405,32 @@ class Envoy:
             assert self.data.tariff is not None  # nosec
             assert self.data.tariff.storage_settings is not None  # nosec
         self.data.tariff.storage_settings.charge_from_grid = False
+        return await self._json_request(
+            URL_TARIFF, {"tariff": self.data.tariff.to_api()}, method="PUT"
+        )
+
+    async def set_storage_mode(self, mode: EnvoyStorageMode) -> dict[str, Any]:
+        """Set the Encharge storage mode."""
+        self._verify_tariff_storage_or_raise()
+        if TYPE_CHECKING:
+            assert self.data is not None  # nosec
+            assert self.data.tariff is not None  # nosec
+            assert self.data.tariff.storage_settings is not None  # nosec
+        if mode not in EnvoyStorageMode:
+            raise ValueError(f"Invalid storage mode: {mode}")
+        self.data.tariff.storage_settings.mode = mode
+        return await self._json_request(
+            URL_TARIFF, {"tariff": self.data.tariff.to_api()}, method="PUT"
+        )
+
+    async def set_reserve_soc(self, value: int) -> dict[str, Any]:
+        """Set the Encharge reserve state of charge."""
+        self._verify_tariff_storage_or_raise()
+        if TYPE_CHECKING:
+            assert self.data is not None  # nosec
+            assert self.data.tariff is not None  # nosec
+            assert self.data.tariff.storage_settings is not None  # nosec
+        self.data.tariff.storage_settings.reserved_soc = round(float(value), 1)
         return await self._json_request(
             URL_TARIFF, {"tariff": self.data.tariff.to_api()}, method="PUT"
         )

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -416,8 +416,8 @@ class Envoy:
             assert self.data is not None  # nosec
             assert self.data.tariff is not None  # nosec
             assert self.data.tariff.storage_settings is not None  # nosec
-        if mode not in EnvoyStorageMode:
-            raise ValueError(f"Invalid storage mode: {mode}")
+        if type(mode) is not EnvoyStorageMode:
+            raise TypeError("Mode must be of type EnvoyStorageMode")
         self.data.tariff.storage_settings.mode = mode
         return await self._json_request(
             URL_TARIFF, {"tariff": self.data.tariff.to_api()}, method="PUT"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1588,7 +1588,7 @@ async def test_with_7_x_firmware(
             {"tariff": envoy.data.tariff.to_api()}
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             await envoy.set_storage_mode("invalid")
 
         bad_envoy = await _get_mock_envoy()


### PR DESCRIPTION
Add support for changing battery storage mode and setting the reserve state-of-charge.

Current known options for the storage mode are in `models.tariff.EnvoyStorageMode`

Backup = full backup
Self Consumption = battery will discharge to the reserve SoC and then pull from grid
Savings Mode = My understanding is this uses the schedule set in Enlighten to pull from the battery during times when energy cost is higher and uses the grid when costs are lower.

For reserve SoC the API seems to want a float, but when making changes from Enlighten and then querying the API I've never seen a decimal besides `.0` - so I set the function up to accept integers and then convert that to a rounded float.