### PR TITLE
fix: Make date field optional in storage settings tariff model

### DIFF
--- a/src/pyenphase/models/tariff.py
+++ b/src/pyenphase/models/tariff.py
@@ -68,7 +68,7 @@ class EnvoyStorageSettings:
     reserved_soc: float
     very_low_soc: int
     charge_from_grid: bool
-    date: str
+    date: str | None
 
     @classmethod
     def from_api(cls, data: dict[str, Any]) -> EnvoyStorageSettings:
@@ -84,16 +84,20 @@ class EnvoyStorageSettings:
             reserved_soc=data["reserved_soc"],
             very_low_soc=data["very_low_soc"],
             charge_from_grid=data["charge_from_grid"],
-            date=data["date"],
+            # Some firmware versions don't return date
+            date=data.get("date"),
         )
 
     def to_api(self) -> dict[str, Any]:
         """Convert to API format."""
-        return {
+        retval = {
             "mode": self.mode.value,
             "operation_mode_sub_type": self.operation_mode_sub_type,
             "reserved_soc": self.reserved_soc,
             "very_low_soc": self.very_low_soc,
             "charge_from_grid": self.charge_from_grid,
-            "date": self.date,
         }
+        if self.date is not None:
+            retval["date"] = self.date
+
+        return retval

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1605,7 +1605,7 @@ async def test_with_7_x_firmware(
             await bad_envoy.update_dry_contact({"id": "NC1"})
 
         dry_contact = envoy.data.dry_contact_settings["NC1"]
-        new_data = {"id": "NC1", "load_name": "NC1 Test"}
+        new_data: dict[str, Any] = {"id": "NC1", "load_name": "NC1 Test"}
         new_model = replace(dry_contact, **new_data)
 
         await envoy.update_dry_contact(new_data)
@@ -1658,6 +1658,15 @@ async def test_with_7_x_firmware(
             == "savings-mode"
         ):
             assert envoy.data.tariff.storage_settings.mode == EnvoyStorageMode.SAVINGS
+
+        storage_settings = envoy.data.tariff.storage_settings
+        new_data = {"charge_from_grid": True}
+        new_model = replace(storage_settings, **new_data)
+
+        if envoy.data.tariff.storage_settings.date is not None:
+            assert new_model.to_api()["date"] == envoy.data.tariff.storage_settings.date
+        else:
+            assert "date" not in new_model.to_api()
 
         # Test setting battery features
         await envoy.enable_charge_from_grid()


### PR DESCRIPTION
Some firmware versions don't return a `date` for storage_settings in `/admin/lib/tariff`

fix for https://github.com/home-assistant/core/issues/103448