### PR TITLE
refactor: rename data parameter of EnvoyUpdater base class to envoy_data

### DIFF
--- a/src/pyenphase/updaters/base.py
+++ b/src/pyenphase/updaters/base.py
@@ -45,5 +45,5 @@ class EnvoyUpdater:
         """Probe the Envoy for this updater and return SupportedFeatures."""
 
     @abstractmethod
-    async def update(self, data: EnvoyData) -> None:
+    async def update(self, envoy_data: EnvoyData) -> None:
         """Update the Envoy for this updater."""


### PR DESCRIPTION
Pylance reports parameter data in updaters update method as different from base class EnvoyUpdater.
As all updaters use envoy_data, renaming the one in base to envoy_data as well.