### PR TITLE
refactor: add empty data structures and tests for phase information

### DIFF
--- a/src/pyenphase/models/common.py
+++ b/src/pyenphase/models/common.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass, field
 
+from ..models.meters import CtType, EnvoyPhaseMode
+
 
 @dataclass(slots=True)
 class CommonProperties:
@@ -16,21 +18,37 @@ class CommonProperties:
     """
 
     # probe properties here, also add to reset_probe_properties
-    phase_count: int = 0  #: number of phases configured in envoy
+    # shared amongst production updaters, needs reset before probe
     production_fallback_list: list[str] = field(
         default_factory=list[str]
     )  #: Fallback production endpoints for Metered without CT
 
     # other properties from here, reset by originator
+
+    # controlled by meters updater
+    phase_count: int = 0  #: number of phases configured in envoy
+    ct_meter_count: int = 0  #: number of active ct meters
+    phase_mode: EnvoyPhaseMode | None = None  #: phase mode configured in the CT meters
+    consumption_meter_type: CtType | None = (
+        None  #: What type of consumption meter is installed, if installed
+    )
+
+    # controlled by
     # none_probe_property: str = "hello world" #: test
 
     def reset_probe_properties(self) -> None:
         """Reset common properties that are initialized during probe.
 
         probe properties are reset at each probe to avoid sticking memories.
-        This should exclude common properties set outside of probe,
-        these should be reset at different moments by different method
-        as divised by originator defining them.
+        This should exclude common properties set outside of probe
+        or controlled by a specific updater, these should be reset at
+        different moments by different method by updaters or owner
+
+        reset properties:
+
+            production_fallback_list shared amongst production updaters
         """
-        self.phase_count = 0
+        # shared amongst production updaters
         self.production_fallback_list = []
+
+        # shared by

--- a/src/pyenphase/models/envoy.py
+++ b/src/pyenphase/models/envoy.py
@@ -22,6 +22,12 @@ class EnvoyData:
     enpower: EnvoyEnpower | None = None
     system_consumption: EnvoySystemConsumption | None = None
     system_production: EnvoySystemProduction | None = None
+    system_consumption_phases: dict[
+        str, EnvoySystemConsumption | None
+    ] | None = None  #: Individual phase consumption data, only for Envoy metered with CT installed
+    system_production_phases: dict[
+        str, EnvoySystemProduction | None
+    ] | None = None  #: Individual phase production data, only for Envoy metered with CT installed
     dry_contact_status: dict[str, EnvoyDryContactStatus] = field(default_factory=dict)
     dry_contact_settings: dict[str, EnvoyDryContactSettings] = field(
         default_factory=dict

--- a/tests/__snapshots__/test_endpoints.ambr
+++ b/tests/__snapshots__/test_endpoints.ambr
@@ -394,12 +394,14 @@
       'watt_hours_today': 7412,
       'watts_now': 806,
     }),
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 179155,
       'watt_hours_lifetime': 26785327,
       'watt_hours_today': 139,
       'watts_now': 166,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'USD',
@@ -1002,12 +1004,14 @@
       ]),
     }),
     'system_consumption': None,
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 366671,
       'watt_hours_lifetime': 133798553,
       'watt_hours_today': 20161,
       'watts_now': 7907,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'USD',
@@ -1290,12 +1294,14 @@
       'watt_hours_today': 15181,
       'watts_now': 1488,
     }),
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 149973,
       'watt_hours_lifetime': 3659507,
       'watt_hours_today': 87,
       'watts_now': 180,
     }),
+    'system_production_phases': None,
     'tariff': None,
   })
 # ---
@@ -1776,12 +1782,14 @@
       }),
     }),
     'system_consumption': None,
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 186012,
       'watt_hours_lifetime': 4545928,
       'watt_hours_today': 14850,
       'watts_now': 3731,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'USD',
@@ -2208,12 +2216,14 @@
       }),
     }),
     'system_consumption': None,
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 111093,
       'watt_hours_lifetime': 702919,
       'watt_hours_today': 4425,
       'watts_now': 751,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'EUR',
@@ -3303,12 +3313,14 @@
       'watt_hours_today': 24293,
       'watts_now': 3803,
     }),
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 218716,
       'watt_hours_lifetime': 19230315,
       'watt_hours_today': 18635,
       'watts_now': 4300,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'USD',
@@ -4370,12 +4382,14 @@
       'watt_hours_today': 24293,
       'watts_now': 3803,
     }),
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 218716,
       'watt_hours_lifetime': 19230315,
       'watt_hours_today': 18635,
       'watts_now': 4300,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'USD',
@@ -5545,12 +5559,14 @@
       'watt_hours_today': 12902,
       'watts_now': 2710,
     }),
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 18431346,
       'watt_hours_lifetime': 18442495,
       'watt_hours_today': 11495,
       'watts_now': 2663,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'USD',
@@ -5960,12 +5976,14 @@
       ]),
     }),
     'system_consumption': None,
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 101742,
       'watt_hours_lifetime': 1544282,
       'watt_hours_today': 10363,
       'watts_now': 586,
     }),
+    'system_production_phases': None,
     'tariff': None,
   })
 # ---
@@ -6161,12 +6179,14 @@
       ]),
     }),
     'system_consumption': None,
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 107011,
       'watt_hours_lifetime': 8717473,
       'watt_hours_today': 7883,
       'watts_now': 3391,
     }),
+    'system_production_phases': None,
     'tariff': None,
   })
 # ---
@@ -6505,12 +6525,14 @@
       ]),
     }),
     'system_consumption': None,
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 189712,
       'watt_hours_lifetime': 6139406,
       'watt_hours_today': 36462,
       'watts_now': 5740,
     }),
+    'system_production_phases': None,
     'tariff': None,
   })
 # ---
@@ -6993,12 +7015,14 @@
       }),
     }),
     'system_consumption': None,
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 0,
       'watt_hours_lifetime': 1152900,
       'watt_hours_today': 0,
       'watts_now': 1317,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'EUR',
@@ -7445,12 +7469,14 @@
       'watt_hours_today': 19904,
       'watts_now': 474,
     }),
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 111093,
       'watt_hours_lifetime': 3183793,
       'watt_hours_today': 4425,
       'watts_now': 488,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'EUR',
@@ -8051,12 +8077,14 @@
       'watt_hours_today': 12423,
       'watts_now': 209,
     }),
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 69492,
       'watt_hours_lifetime': 4351113,
       'watt_hours_today': 5113,
       'watts_now': -6,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'EUR',
@@ -8653,12 +8681,14 @@
       'watt_hours_today': 63,
       'watts_now': 519,
     }),
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 73003,
       'watt_hours_lifetime': 2432970,
       'watt_hours_today': 1,
       'watts_now': 0,
     }),
+    'system_production_phases': None,
     'tariff': dict({
       'currency': dict({
         'code': 'EUR',
@@ -9811,12 +9841,14 @@
       'watt_hours_today': 0,
       'watts_now': 5210,
     }),
+    'system_consumption_phases': None,
     'system_production': dict({
       'watt_hours_last_7_days': 1456164,
       'watt_hours_lifetime': 1510206,
       'watt_hours_today': 55045,
       'watts_now': 13028,
     }),
+    'system_production_phases': None,
     'tariff': None,
   })
 # ---

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -2121,13 +2121,3 @@ async def test_with_7_x_firmware(
         envoy._common_properties.consumption_meter_type
         == common_properties["consumptionMeter"]
     )
-
-    if production_phases is None:
-        assert data.system_production_phases is None
-    if consumption_phases is None:
-        assert data.system_consumption_phases is None
-
-    if data.system_production_phases is None:
-        assert not production_phases
-    if envoy.data.system_consumption_phases is None:
-        assert not consumption_phases


### PR DESCRIPTION
Add production and consumption records for phases to envoy data model.
Extend common properties with phase setup information.
Add tests for empty data structures added.
Update snapshot with empty data structures for production and consumption phases.
New structures are not used yet, they all contain their default values.