### PR TITLE
chore: Bump python for readthedocs to 3.11

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.10"
+    python: "3.11"
   jobs:
     post_create_environment:
       # Install poetry


### PR DESCRIPTION
Switch to python 3.11 for readthedocs as pyenphase code uses StrEnum which causes build on 3.10 to fail