### PR TITLE
refactor: Add CT meters model datastructures

### DIFF
--- a/src/pyenphase/models/envoy.py
+++ b/src/pyenphase/models/envoy.py
@@ -7,6 +7,7 @@ from .dry_contacts import EnvoyDryContactSettings, EnvoyDryContactStatus
 from .encharge import EnvoyEncharge, EnvoyEnchargeAggregate, EnvoyEnchargePower
 from .enpower import EnvoyEnpower
 from .inverter import EnvoyInverter
+from .meters import EnvoyMeterData
 from .system_consumption import EnvoySystemConsumption
 from .system_production import EnvoySystemProduction
 from .tariff import EnvoyTariff
@@ -28,6 +29,14 @@ class EnvoyData:
     system_production_phases: dict[
         str, EnvoySystemProduction | None
     ] | None = None  #: Individual phase production data, only for Envoy metered with CT installed
+    ctmeter_production: EnvoyMeterData | None = None  #: Production CT Meter data
+    ctmeter_consumption: EnvoyMeterData | None = None  #: Consumption CT Meter data
+    ctmeter_production_phases: dict[
+        str, EnvoyMeterData
+    ] | None = None  #: Production CT Meter Individual phase data
+    ctmeter_consumption_phases: dict[
+        str, EnvoyMeterData
+    ] | None = None  #: Consumption CT Meter Individual phase data
     dry_contact_status: dict[str, EnvoyDryContactStatus] = field(default_factory=dict)
     dry_contact_settings: dict[str, EnvoyDryContactSettings] = field(
         default_factory=dict

--- a/src/pyenphase/models/meters.py
+++ b/src/pyenphase/models/meters.py
@@ -1,8 +1,9 @@
 """Model for the Envoy's CT Meters."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import StrEnum
-from typing import TypedDict
+from typing import Any, TypedDict
 
 
 class EnvoyPhaseMode(StrEnum):
@@ -43,3 +44,57 @@ class CtMeterData(TypedDict):
     phaseCount: int
     meteringStatus: CtMeterStatus
     statusFlags: list[CtStatusFlags]
+
+
+@dataclass(slots=True)
+class EnvoyMeterData:
+    """Model for the Envoy's CT meter data."""
+
+    eid: str  #: CT meter identifier
+    timestamp: int  #: Time of measurement
+    energy_delivered: int  #: Lifetime Energy delivered through CT
+    energy_received: int  #: Lifetime Energy received through CT
+    active_power: int  #: Current power exchang through CT, positive is delivering, negative is receiving
+    power_factor: float  #: Power factor reported for CT measurement
+    voltage: float  #: Voltage on circuit, when multiphase sum of voltage of individual phases
+    current: float  #: current measured by CT
+    frequency: float  #: frequency measured by CT
+    state: CtState | None  #: Actual State of CT
+    measurement_type: CtType | None  #: Measurement type configured for CT
+    metering_status: CtMeterStatus | None  #: CT Measurement status
+    status_flags: list[CtStatusFlags] | None  #: CT status flags.
+
+    @classmethod
+    def from_api(
+        cls, data: dict[str, Any], meter_status: CtMeterData
+    ) -> EnvoyMeterData:
+        """Return CT meter data from /ivp/meters and ivp/meters/reading json."""
+        return cls(
+            eid=data["eid"],
+            timestamp=data["timestamp"],
+            energy_delivered=int(round(data["actEnergyDlvd"])),
+            energy_received=int(round(data["actEnergyRcvd"])),
+            active_power=int(round(data["activePower"])),
+            power_factor=data["pwrFactor"],
+            voltage=data["voltage"],
+            current=data["current"],
+            frequency=data["freq"],
+            state=meter_status["state"],
+            measurement_type=meter_status["measurementType"],
+            metering_status=meter_status["meteringStatus"],
+            status_flags=meter_status["statusFlags"],
+        )
+
+    @classmethod
+    def from_phase(
+        cls, data: dict[str, Any], meter_status: CtMeterData, phase: int
+    ) -> EnvoyMeterData | None:
+        """Return CT meter phase data from /ivp/meters and ivp/meters/reading json."""
+        if "channels" not in data:
+            return None
+        # phase data is in channels list
+        channels = data["channels"]
+        if len(channels) <= phase:
+            return None
+
+        return cls.from_api(channels[phase], meter_status)

--- a/tests/__snapshots__/test_endpoints.ambr
+++ b/tests/__snapshots__/test_endpoints.ambr
@@ -1,6 +1,10 @@
 # serializer version: 1
 # name: test_with_7_x_firmware[4.10.35]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -443,6 +447,10 @@
 # ---
 # name: test_with_7_x_firmware[5.0.62]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -1032,6 +1040,10 @@
 # ---
 # name: test_with_7_x_firmware[7.3.130]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -1307,6 +1319,10 @@
 # ---
 # name: test_with_7_x_firmware[7.3.130_no_consumption]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -1835,6 +1851,10 @@
 # ---
 # name: test_with_7_x_firmware[7.3.466_metered_disabled_cts]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -2279,6 +2299,10 @@
 # ---
 # name: test_with_7_x_firmware[7.3.517]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -3348,6 +3372,10 @@
 # ---
 # name: test_with_7_x_firmware[7.3.517_legacy_savings_mode]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -4417,6 +4445,10 @@
 # ---
 # name: test_with_7_x_firmware[7.3.517_system_2]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': None,
@@ -5786,6 +5818,10 @@
 # ---
 # name: test_with_7_x_firmware[7.6.114_without_cts]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -5989,6 +6025,10 @@
 # ---
 # name: test_with_7_x_firmware[7.6.175]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -6192,6 +6232,10 @@
 # ---
 # name: test_with_7_x_firmware[7.6.175_standard]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -6538,6 +6582,10 @@
 # ---
 # name: test_with_7_x_firmware[7.6.175_total]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -7083,6 +7131,10 @@
 # ---
 # name: test_with_7_x_firmware[7.6.175_with_cts]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -7532,6 +7584,10 @@
 # ---
 # name: test_with_7_x_firmware[7.6.175_with_cts_3phase]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -8178,6 +8234,10 @@
 # ---
 # name: test_with_7_x_firmware[7.6.185_with_cts_and_battery_3t]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -8782,6 +8842,10 @@
 # ---
 # name: test_with_7_x_firmware[8.1.41]
   dict({
+    'ctmeter_consumption': None,
+    'ctmeter_consumption_phases': None,
+    'ctmeter_production': None,
+    'ctmeter_production_phases': None,
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,


### PR DESCRIPTION
Envoy Metered with consumption Current Transformers (CT) implemented report CT details in /ivp/meters/readings. For the consumption CT configured in `Solar with Load` this provides information on net-production (grid export) and net-consumption (grid-import). Net-consumption is also reported in /production as an increasing/decreasing total of import and export, CT readings however provides these as 2 increasing properties. [^1]

[^1]: variations between firmware release may exist.

This PR is step 1 of 3 to implement #69. It adds the meters model and Envoy data structures to store the CT data as well as tests for these. In addition to energy delivered and received it collects `active power`, `frequency`, `voltage`, `Current`, `power factor`, `State`, `measurement type`, `metering status` and `status flags` for the CT. 