### PR TITLE
refactor: add empty data structures for storage CT

### DIFF
--- a/src/pyenphase/models/common.py
+++ b/src/pyenphase/models/common.py
@@ -32,6 +32,12 @@ class CommonProperties:
     consumption_meter_type: CtType | None = (
         None  #: What type of consumption meter is installed, if installed
     )
+    production_meter_type: CtType | None = (
+        None  #: What type of production meter is installed, if installed
+    )
+    storage_meter_type: CtType | None = (
+        None  #: What type of storage meter is installed, if installed
+    )
     # controlled by production updater
     active_phase_count: int = 0  #: number of phases actually reporting phase data
 

--- a/src/pyenphase/models/envoy.py
+++ b/src/pyenphase/models/envoy.py
@@ -31,12 +31,16 @@ class EnvoyData:
     ] | None = None  #: Individual phase production data, only for Envoy metered with CT installed
     ctmeter_production: EnvoyMeterData | None = None  #: Production CT Meter data
     ctmeter_consumption: EnvoyMeterData | None = None  #: Consumption CT Meter data
+    ctmeter_storage: EnvoyMeterData | None = None  #: Storage CT Meter data
     ctmeter_production_phases: dict[
         str, EnvoyMeterData
     ] | None = None  #: Production CT Meter Individual phase data
     ctmeter_consumption_phases: dict[
         str, EnvoyMeterData
     ] | None = None  #: Consumption CT Meter Individual phase data
+    ctmeter_storage_phases: dict[
+        str, EnvoyMeterData
+    ] | None = None  #: Storage CT Meter Individual phase data
     dry_contact_status: dict[str, EnvoyDryContactStatus] = field(default_factory=dict)
     dry_contact_settings: dict[str, EnvoyDryContactSettings] = field(
         default_factory=dict

--- a/src/pyenphase/models/meters.py
+++ b/src/pyenphase/models/meters.py
@@ -16,6 +16,7 @@ class CtType(StrEnum):
     PRODUCTION = "production"
     NET_CONSUMPTION = "net-consumption"
     TOTAL_CONSUMPTION = "total-consumption"
+    STORAGE = "storage"
 
 
 class CtState(StrEnum):

--- a/src/pyenphase/updaters/meters.py
+++ b/src/pyenphase/updaters/meters.py
@@ -25,6 +25,7 @@ class EnvoyMetersUpdater(EnvoyUpdater):
     )
     production_meter_type: CtType | None = None  #: Production CT type
     consumption_meter_type: CtType | None = None  #: Consumpion CT type (net or total)
+    storage_meter_type: CtType | None = None  #: Storage CT type
     phase_mode: EnvoyPhaseMode | None = (
         None  #: Phase mode configured (Single, Dual or Three)
     )
@@ -34,12 +35,15 @@ class EnvoyMetersUpdater(EnvoyUpdater):
     )
     production_meter_eid: str | None = None  #: Production CT identifier
     consumption_meter_eid: str | None = None  #: Consumption CT identifier
+    storage_meter_eid: str | None = None  #: Storage CT identifier
 
     def _set_common_properties(self) -> None:
         """Set Envoy common properties we own and control"""
         self._common_properties.phase_count = self.phase_count
         self._common_properties.phase_mode = self.phase_mode
         self._common_properties.consumption_meter_type = self.consumption_meter_type
+        self._common_properties.production_meter_type = self.production_meter_type
+        self._common_properties.storage_meter_type = self.storage_meter_type
         self._common_properties.ct_meter_count = self.ct_meters_count
 
     async def probe(
@@ -67,17 +71,17 @@ class EnvoyMetersUpdater(EnvoyUpdater):
         self.phase_mode = (
             None  # Phase mode only if ct meters are installed and configured
         )
-        self.consumption_meter_type = (
-            None  # Type of consumption ct only known if installed.
-        )
+        self.production_meter_type = None  # Type of production CT If installed
+        self.consumption_meter_type = None  # Type of consumption ct if installed.
+        self.storage_meter_type = None  # Type of storage CT If installed
 
         # set the defaults in global common properties in case we exit early
         self._set_common_properties()
 
         # set local defaults not shared in common properties
-        self.production_meter_type = None
         self.production_meter_eid = None
         self.consumption_meter_eid = None
+        self.storage_meter_eid = None
 
         try:
             meters_json: list[CtMeterData] | None = await self._json_probe_request(

--- a/tests/__snapshots__/test_endpoints.ambr
+++ b/tests/__snapshots__/test_endpoints.ambr
@@ -101,6 +101,8 @@
         'voltage': 123.836,
       }),
     }),
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -711,6 +713,8 @@
     'ctmeter_consumption_phases': None,
     'ctmeter_production': None,
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -1304,6 +1308,8 @@
     'ctmeter_consumption_phases': None,
     'ctmeter_production': None,
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -1631,6 +1637,8 @@
         'voltage': 120.946,
       }),
     }),
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -2327,6 +2335,8 @@
     'ctmeter_consumption_phases': None,
     'ctmeter_production': None,
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -2775,6 +2785,8 @@
     'ctmeter_consumption_phases': None,
     'ctmeter_production': None,
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -3848,6 +3860,8 @@
     'ctmeter_consumption_phases': None,
     'ctmeter_production': None,
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -5017,6 +5031,8 @@
         'voltage': 122.28,
       }),
     }),
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': None,
@@ -6554,6 +6570,8 @@
     'ctmeter_consumption_phases': None,
     'ctmeter_production': None,
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -6761,6 +6779,8 @@
     'ctmeter_consumption_phases': None,
     'ctmeter_production': None,
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -6968,6 +6988,8 @@
     'ctmeter_consumption_phases': None,
     'ctmeter_production': None,
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -7318,6 +7340,8 @@
     'ctmeter_consumption_phases': None,
     'ctmeter_production': None,
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -7897,6 +7921,8 @@
       'voltage': 235.236,
     }),
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -8642,6 +8668,8 @@
         'voltage': 11.469,
       }),
     }),
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -9486,6 +9514,8 @@
       'voltage': 238.524,
     }),
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -10258,6 +10288,8 @@
     'ctmeter_consumption_phases': None,
     'ctmeter_production': None,
     'ctmeter_production_phases': None,
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -11468,6 +11500,8 @@
         'voltage': 121.143,
       }),
     }),
+    'ctmeter_storage': None,
+    'ctmeter_storage_phases': None,
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5,


### PR DESCRIPTION
First step to implement battery storage CT for use with HA Energy dashboard.

This PR creates the empty data structures needed to collect the storage CT data from /ivp/meters and ivp/meters/readings. The data itself is not yet included. The structures are the same as for the production and consumption CT. Some refactoring done to abandon the assumption no more as 2 CT types can report.

Test snapshot updated for the empty data structures added.

A next PR will add data collection and documentation update.


