### PR TITLE
fix: endless loop on envoy unreachable

### DIFF
--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -42,7 +42,7 @@ LOCAL_TIMEOUT = httpx.Timeout(
     # need to set a long timeout for the read and a short timeout
     # for the connect
     timeout=10.0,
-    read=60.0,
+    read=45.0,
 )
 
 # Requests should no longer retry after max delay (sec) or times since first try

--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -45,8 +45,9 @@ LOCAL_TIMEOUT = httpx.Timeout(
     read=60.0,
 )
 
-# Requests should no longer retry after max delay (sec) since first try
+# Requests should no longer retry after max delay (sec) or times since first try
 MAX_REQUEST_DELAY = 50
+MAX_REQUEST_ATTEMPTS = 4
 
 
 class SupportedFeatures(enum.IntFlag):

--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -45,6 +45,9 @@ LOCAL_TIMEOUT = httpx.Timeout(
     read=60.0,
 )
 
+# Requests should no longer retry after max delay (sec) since first try
+MAX_REQUEST_DELAY = 50
+
 
 class SupportedFeatures(enum.IntFlag):
     """Features available from Envoy"""

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -240,8 +240,7 @@ class Envoy:
                 data=orjson.dumps(data),
             )
         else:
-            if debugon:
-                _LOGGER.debug("Requesting %s with timeout %s", url, self._timeout)
+            _LOGGER.debug("Requesting %s with timeout %s", url, self._timeout)
             response = await self._client.get(
                 url,
                 headers={**DEFAULT_HEADERS, **self.auth.headers},

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -105,7 +105,7 @@ class Envoy:
         )  # nosec
         self.auth: EnvoyAuth | None = None
         self._host = host
-        self._firmware = EnvoyFirmware(self._client, self._host, self._timeout)
+        self._firmware = EnvoyFirmware(self._client, self._host)
         self._supported_features: SupportedFeatures | None = None
         self._updaters: list[EnvoyUpdater] = []
         self._endpoint_cache: dict[str, httpx.Response] = {}

--- a/src/pyenphase/firmware.py
+++ b/src/pyenphase/firmware.py
@@ -53,10 +53,8 @@ class EnvoyFirmware:
     )
     async def _get_info(self) -> httpx.Response:
         """Obtain the firmware version for Envoy authentication."""
-        debugon = _LOGGER.isEnabledFor(logging.DEBUG)
         url = f"https://{self._host}/info"
-        if debugon:
-            _LOGGER.debug("Requesting %s with timeout %s", url, self._timeout)
+        _LOGGER.debug("Requesting %s with timeout %s", url, self._timeout)
         try:
             return await self._client.get(url, timeout=self._timeout)
         except (httpx.ConnectError, httpx.TimeoutException):
@@ -64,8 +62,7 @@ class EnvoyFirmware:
             # as a fallback, worse sometimes http will redirect to https://localhost
             # which is not helpful
             url = f"http://{self._host}/info"
-            if debugon:
-                _LOGGER.debug("Retrying to %s with timeout %s", url, self._timeout)
+            _LOGGER.debug("Retrying to %s with timeout %s", url, self._timeout)
             return await self._client.get(url, timeout=self._timeout)
 
     async def setup(self) -> None:

--- a/src/pyenphase/firmware.py
+++ b/src/pyenphase/firmware.py
@@ -28,7 +28,6 @@ class EnvoyFirmware:
         "_serial_number",
         "_part_number",
         "_timeout",
-        "_max_request_delay",
     )
 
     def __init__(
@@ -36,7 +35,6 @@ class EnvoyFirmware:
         _client: httpx.AsyncClient,
         host: str,
         timeout: float | httpx.Timeout | None = None,
-        max_request_delay: int | None = None,
     ) -> None:
         """Initialize the Envoy firmware version."""
         self._client = _client
@@ -45,9 +43,8 @@ class EnvoyFirmware:
         self._serial_number: str | None = None
         self._part_number: str | None = None
         self._timeout = timeout or LOCAL_TIMEOUT
-        self._max_request_delay = max_request_delay or MAX_REQUEST_DELAY
 
-    @retry(  # need to use constant MAX_REQUEST_DELAY rather then self._max_request_delay
+    @retry(
         retry=retry_if_exception_type((httpx.NetworkError, httpx.RemoteProtocolError)),
         wait=wait_random_exponential(multiplier=2, max=5),
         stop=stop_after_delay(MAX_REQUEST_DELAY)

--- a/src/pyenphase/firmware.py
+++ b/src/pyenphase/firmware.py
@@ -27,14 +27,12 @@ class EnvoyFirmware:
         "_firmware_version",
         "_serial_number",
         "_part_number",
-        "_timeout",
     )
 
     def __init__(
         self,
         _client: httpx.AsyncClient,
         host: str,
-        timeout: float | httpx.Timeout | None = None,
     ) -> None:
         """Initialize the Envoy firmware version."""
         self._client = _client
@@ -42,7 +40,6 @@ class EnvoyFirmware:
         self._firmware_version: str | None = None
         self._serial_number: str | None = None
         self._part_number: str | None = None
-        self._timeout = timeout or LOCAL_TIMEOUT
 
     @retry(
         retry=retry_if_exception_type((httpx.NetworkError, httpx.RemoteProtocolError)),
@@ -54,16 +51,16 @@ class EnvoyFirmware:
     async def _get_info(self) -> httpx.Response:
         """Obtain the firmware version for Envoy authentication."""
         url = f"https://{self._host}/info"
-        _LOGGER.debug("Requesting %s with timeout %s", url, self._timeout)
+        _LOGGER.debug("Requesting %s with timeout %s", url, LOCAL_TIMEOUT)
         try:
-            return await self._client.get(url, timeout=self._timeout)
+            return await self._client.get(url, timeout=LOCAL_TIMEOUT)
         except (httpx.ConnectError, httpx.TimeoutException):
             # Firmware < 7.0.0 does not support HTTPS so we need to try HTTP
             # as a fallback, worse sometimes http will redirect to https://localhost
             # which is not helpful
             url = f"http://{self._host}/info"
-            _LOGGER.debug("Retrying to %s with timeout %s", url, self._timeout)
-            return await self._client.get(url, timeout=self._timeout)
+            _LOGGER.debug("Retrying to %s with timeout %s", url, LOCAL_TIMEOUT)
+            return await self._client.get(url, timeout=LOCAL_TIMEOUT)
 
     async def setup(self) -> None:
         """Obtain the firmware version for Envoy authentication."""

--- a/src/pyenphase/firmware.py
+++ b/src/pyenphase/firmware.py
@@ -1,10 +1,23 @@
+"""Envoy Firmware detection"""
+import logging
+from typing import TYPE_CHECKING
+
 import httpx
+from anyio import EndOfStream
 from awesomeversion import AwesomeVersion
 from lxml import etree  # nosec
-from tenacity import retry, retry_if_exception_type, wait_random_exponential
+from tenacity import (
+    RetryError,
+    retry,
+    retry_if_exception_type,
+    stop_after_delay,
+    wait_random_exponential,
+)
 
-from .const import LOCAL_TIMEOUT
+from .const import LOCAL_TIMEOUT, MAX_REQUEST_DELAY
 from .exceptions import EnvoyFirmwareCheckError, EnvoyFirmwareFatalCheckError
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class EnvoyFirmware:
@@ -16,37 +29,57 @@ class EnvoyFirmware:
         "_firmware_version",
         "_serial_number",
         "_part_number",
+        "_timeout",
+        "_max_request_delay",
     )
 
-    def __init__(self, _client: httpx.AsyncClient, host: str) -> None:
+    def __init__(
+        self,
+        _client: httpx.AsyncClient,
+        host: str,
+        timeout: float | httpx.Timeout | None = None,
+        max_request_delay: int | None = None,
+    ) -> None:
         """Initialize the Envoy firmware version."""
         self._client = _client
         self._host = host
         self._firmware_version: str | None = None
         self._serial_number: str | None = None
         self._part_number: str | None = None
+        self._timeout = timeout or LOCAL_TIMEOUT
+        self._max_request_delay = max_request_delay or MAX_REQUEST_DELAY
 
-    @retry(
-        retry=retry_if_exception_type((httpx.NetworkError, httpx.RemoteProtocolError)),
-        wait=wait_random_exponential(multiplier=2, max=5),
-    )
-    async def _get_info(self) -> None:
+        if not TYPE_CHECKING:
+            EnvoyFirmware._get_info = retry(
+                retry=retry_if_exception_type(
+                    (httpx.NetworkError, httpx.RemoteProtocolError)
+                ),
+                wait=wait_random_exponential(multiplier=2, max=5),
+                stop=stop_after_delay(self._max_request_delay),
+                reraise=True,
+            )(EnvoyFirmware._get_info)
+
+    async def _get_info(self) -> httpx.Response:
         """Obtain the firmware version for Envoy authentication."""
+        debugon = _LOGGER.isEnabledFor(logging.DEBUG)
+        url = f"https://{self._host}/info"
+        if debugon:
+            _LOGGER.debug("Requesting %s with timeout %s", url, self._timeout)
         try:
-            return await self._client.get(
-                f"https://{self._host}/info", timeout=LOCAL_TIMEOUT
-            )
+            return await self._client.get(url, timeout=self._timeout)
         except (httpx.ConnectError, httpx.TimeoutException):
             # Firmware < 7.0.0 does not support HTTPS so we need to try HTTP
             # as a fallback, worse sometimes http will redirect to https://localhost
             # which is not helpful
-            return await self._client.get(
-                f"http://{self._host}/info", timeout=LOCAL_TIMEOUT
-            )
+            url = f"http://{self._host}/info"
+            if debugon:
+                _LOGGER.debug("Retrying to %s with timeout %s", url, self._timeout)
+            return await self._client.get(url, timeout=self._timeout)
 
     async def setup(self) -> None:
         """Obtain the firmware version for Envoy authentication."""
         # <envoy>/info will return XML with the firmware version
+        debugon = _LOGGER.isEnabledFor(logging.DEBUG)
         try:
             result = await self._get_info()
         except httpx.TimeoutException:
@@ -55,8 +88,25 @@ class EnvoyFirmware:
             raise EnvoyFirmwareFatalCheckError(500, "Unable to connect to Envoy")
         except httpx.HTTPError:
             raise EnvoyFirmwareCheckError(500, "Unable to query firmware version")
+        except RetryError:
+            raise EnvoyFirmwareFatalCheckError(
+                500, "Unable to connect to Envoy after retries"
+            )
+        except EndOfStream:
+            raise EnvoyFirmwareFatalCheckError(
+                500, "Unable to connect to Envoy after retries"
+            )
 
-        if result.status_code == 200:
+        if (status_code := result.status_code) == 200:
+            if debugon:
+                content_type = result.headers.get("content-type")
+                content = result.content
+                _LOGGER.debug(
+                    "Request reply status %s: %s %s",
+                    status_code,
+                    content_type,
+                    content,
+                )
             xml = etree.fromstring(result.content)  # nosec
             if (device_tag := xml.find("device")) is not None:
                 if (software_tag := device_tag.find("software")) is not None:

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -1,0 +1,468 @@
+"""Test tenacety retry functioning."""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import httpx
+import orjson
+import pytest
+import respx
+from httpx import Response
+from tenacity import stop_after_attempt, stop_after_delay, wait_none
+
+from pyenphase import Envoy
+from pyenphase.exceptions import (
+    EnvoyAuthenticationRequired,
+    EnvoyFirmwareCheckError,
+    EnvoyFirmwareFatalCheckError,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _fixtures_dir() -> Path:
+    return Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(version: str, name: str) -> str:
+    with open(_fixtures_dir() / version / name) as read_in:
+        return read_in.read()
+
+
+def _load_json_fixture(version: str, name: str) -> dict[str, Any]:
+    return orjson.loads(_load_fixture(version, name))
+
+
+def _start_7_firmware_mock():
+    respx.post("https://enlighten.enphaseenergy.com/login/login.json?").mock(
+        return_value=Response(
+            200,
+            json={
+                "session_id": "1234567890",
+                "user_id": "1234567890",
+                "user_name": "test",
+                "first_name": "Test",
+                "is_consumer": True,
+                "manager_token": "1234567890",
+            },
+        )
+    )
+    respx.post("https://entrez.enphaseenergy.com/tokens").mock(
+        return_value=Response(200, text="token")
+    )
+    respx.get("/auth/check_jwt").mock(return_value=Response(200, json={}))
+
+
+def prep_envoy(version: str, info: bool = False, meters: bool = True) -> None:
+    """Mock envoy replies in correct order"""
+    if info:
+        respx.get("/info").mock(
+            return_value=Response(200, text=_load_fixture(version, "info"))
+        )
+
+    if meters:
+        respx.get("/ivp/meters").mock(return_value=Response(200, text="[]"))
+
+    respx.get("/production").mock(
+        return_value=Response(200, text=_load_fixture(version, "production"))
+    )
+    respx.get("/production.json").mock(
+        return_value=Response(200, text=_load_fixture(version, "production.json"))
+    )
+    respx.get("/api/v1/production").mock(
+        return_value=Response(
+            200, json=_load_json_fixture(version, "api_v1_production")
+        )
+    )
+    respx.get("/api/v1/production/inverters").mock(
+        return_value=Response(
+            200, json=_load_json_fixture(version, "api_v1_production_inverters")
+        )
+    )
+    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_full_connected_from_start_with_7_6_175_standard():
+    """Test envoy connected and replying from start"""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+    version = "7.6.175_standard"
+    _start_7_firmware_mock()
+    prep_envoy(version=version, info=True)
+
+    envoy = Envoy("127.0.0.1")
+    # remove the waits between retries for this test and set known retries
+    envoy._firmware._get_info.retry.wait = wait_none()
+    envoy._firmware._get_info.retry.stop = stop_after_attempt(3) | stop_after_delay(50)
+
+    await envoy.setup()
+    await envoy.authenticate("username", "password")
+
+    # Ensure that there was 1 attempt only.
+    stats: dict[str, Any] = envoy._firmware._get_info.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 1
+
+    assert envoy.firmware == "7.6.175"
+    assert envoy.part_number == "800-00656-r06"
+
+    data = await envoy.update()
+    assert data
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_full_disconnected_from_start_with_7_6_175_standard():
+    """Test envoy disconnect at start, should return EnvoyFirmwareFatalCheckError."""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+    _start_7_firmware_mock()
+    envoy = Envoy("127.0.0.1")
+    # remove the waits between retries for this test and set known retries
+    envoy._firmware._get_info.retry.wait = wait_none()
+    envoy._firmware._get_info.retry.stop = stop_after_attempt(3) | stop_after_delay(50)
+
+    respx.get("/info").mock(
+        return_value=Response(200, text="")
+    ).side_effect = httpx.ConnectError("Test timeoutexception")
+
+    with pytest.raises(EnvoyFirmwareFatalCheckError):
+        await envoy.setup()
+
+    # Ensure that there were 3 attempts.
+    stats: dict[str, Any] = envoy._firmware._get_info.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 3
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_2_timeout_from_start_with_7_6_175_standard():
+    """Test envoy timeout at start, timeout is not in retry loop."""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+    _start_7_firmware_mock()
+    envoy = Envoy("127.0.0.1")
+    envoy._firmware._get_info.retry.wait = wait_none()
+    envoy._firmware._get_info.retry.stop = stop_after_attempt(3) | stop_after_delay(50)
+
+    # test if 2 timeouts return failed
+    respx.get("/info").mock(return_value=Response(200, text="")).side_effect = [
+        httpx.TimeoutException("Test timeoutexception"),
+        httpx.TimeoutException("Test timeoutexception"),
+    ]
+
+    with pytest.raises(EnvoyFirmwareFatalCheckError):
+        await envoy.setup()
+
+    # Ensure that there were no retries.
+    stats: dict[str, Any] = envoy._firmware._get_info.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_httperror_from_start_with_7_6_175_standard():
+    """Test envoy httperror at start, is not in retry loop."""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+    version = "7.6.175_standard"
+    _start_7_firmware_mock()
+    prep_envoy(version=version)
+
+    envoy = Envoy("127.0.0.1")
+    envoy._firmware._get_info.retry.wait = wait_none()
+    envoy._firmware._get_info.retry.stop = stop_after_attempt(3) | stop_after_delay(50)
+
+    # test if 2 timeouts return failed
+    respx.get("/info").mock().side_effect = [
+        httpx.HTTPError("Test timeoutexception"),
+        Response(200, text=_load_fixture(version, "info")),
+    ]
+
+    with pytest.raises(EnvoyFirmwareCheckError):
+        await envoy.setup()
+
+    # Ensure that there were no retries.
+    stats: dict[str, Any] = envoy._firmware._get_info.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_1_timeout_from_start_with_7_6_175_standard():
+    """Test envoy timeout at start, timeout is not in retry loop but tries http after https."""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+    version = "7.6.175_standard"
+    _start_7_firmware_mock()
+    prep_envoy(version=version)
+
+    envoy = Envoy("127.0.0.1")
+    envoy._firmware._get_info.retry.wait = wait_none()
+    envoy._firmware._get_info.retry.stop = stop_after_attempt(3) | stop_after_delay(50)
+
+    # test if 2 timeouts return failed
+    respx.get("/info").mock().side_effect = [
+        httpx.TimeoutException("Test timeoutexception"),
+        Response(200, text=_load_fixture(version, "info")),
+    ]
+
+    await envoy.setup()
+    await envoy.authenticate("username", "password")
+
+    # Ensure that there were no retries.
+    stats: dict[str, Any] = envoy._firmware._get_info.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 1
+
+    assert envoy.firmware == "7.6.175"
+    assert envoy.part_number == "800-00656-r06"
+
+    data = await envoy.update()
+    assert data
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_5_not_connected_at_start_with_7_6_175_standard():
+    """Test 5 connection failures at start and last one works"""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+    version = "7.6.175_standard"
+    _start_7_firmware_mock()
+    prep_envoy(version)
+
+    envoy = Envoy("127.0.0.1")
+    # remove the waits between retries for this test and set known retries
+    envoy._firmware._get_info.retry.wait = wait_none()
+    envoy._firmware._get_info.retry.stop = stop_after_attempt(3) | stop_after_delay(50)
+
+    # we need 2 side effects for each try as https and then http is attempted
+    respx.get("/info").mock().side_effect = [
+        httpx.ConnectError("Test timeoutexception"),
+        httpx.ConnectError("Test timeoutexception"),
+        httpx.ConnectError("Test timeoutexception"),
+        httpx.ConnectError("Test timeoutexception"),
+        httpx.ConnectError("Test timeoutexception"),
+        Response(200, text=_load_fixture(version, "info")),
+    ]
+    await envoy.setup()
+    await envoy.authenticate("username", "password")
+
+    # Ensure that there were no retries.
+    stats: dict[str, Any] = envoy._firmware._get_info.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 3
+
+    assert envoy.firmware == "7.6.175"
+    assert envoy.part_number == "800-00656-r06"
+
+    data = await envoy.update()
+    assert data
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_2_network_errors_at_start_with_7_6_175_standard():
+    """Test 2 network error failures at start and 3th works"""
+    logging.getLogger("pyenphase").setLevel(logging.WARN)
+    version = "7.6.175_standard"
+    _start_7_firmware_mock()
+    prep_envoy(version)
+
+    envoy = Envoy("127.0.0.1")
+    # remove the waits between retries for this test and set known retries
+    envoy._firmware._get_info.retry.wait = wait_none()
+    envoy._firmware._get_info.retry.stop = stop_after_attempt(3) | stop_after_delay(50)
+
+    # we need 2 side effects for each try as https and then http is attempted
+    respx.get("/info").mock().side_effect = [
+        httpx.NetworkError("Test timeoutexception"),
+        httpx.RemoteProtocolError("Test timeoutexception"),
+        Response(200, text=_load_fixture(version, "info")),
+    ]
+
+    await envoy.setup()
+    await envoy.authenticate("username", "password")
+
+    # Ensure that there were no retries.
+    stats: dict[str, Any] = envoy._firmware._get_info.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 3
+
+    assert envoy.firmware == "7.6.175"
+    assert envoy.part_number == "800-00656-r06"
+
+    data = await envoy.update()
+    assert data
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_3_network_errors_at_start_with_7_6_175_standard():
+    """Test 3 network error failures at start"""
+    logging.getLogger("pyenphase").setLevel(logging.WARN)
+    version = "7.6.175_standard"
+    _start_7_firmware_mock()
+    prep_envoy(version)
+
+    envoy = Envoy("127.0.0.1")
+    # remove the waits between retries for this test and set known retries
+    envoy._firmware._get_info.retry.wait = wait_none()
+    envoy._firmware._get_info.retry.stop = stop_after_attempt(3) | stop_after_delay(50)
+
+    # we need 2 side effects for each try as https and then http is attempted
+    respx.get("/info").mock().side_effect = [
+        httpx.NetworkError("Test timeoutexception"),
+        httpx.RemoteProtocolError("Test timeoutexception"),
+        httpx.NetworkError("Test timeoutexception"),
+    ]
+
+    with pytest.raises(EnvoyFirmwareCheckError):
+        await envoy.setup()
+
+    # Ensure that there were no retries.
+    stats: dict[str, Any] = envoy._firmware._get_info.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 3
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_noconnection_at_probe_with_7_6_175_standard():
+    """Test 3 network error failures at start"""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+    version = "7.6.175_standard"
+    _start_7_firmware_mock()
+    prep_envoy(version, info=True)
+
+    envoy = Envoy("127.0.0.1")
+    # remove the waits between retries for this test and set known retries
+    envoy.probe_request.retry.wait = wait_none()
+    envoy.probe_request.retry.stop = stop_after_attempt(3) | stop_after_delay(50)
+
+    await envoy.setup()
+    await envoy.authenticate("username", "password")
+
+    # Ensure that there were no retries.
+    stats: dict[str, Any] = envoy._firmware._get_info.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 1
+
+    # Probe is re-calling retried probe_request before returning
+    # we can only see stats for the last request done.
+    # force 3 retries for last one
+    respx.get("/admin/lib/tariff").mock().side_effect = [
+        httpx.NetworkError("Test timeoutexception"),
+        httpx.RemoteProtocolError("Test timeoutexception"),
+        httpx.TimeoutException("Test timeoutexception"),
+    ]
+
+    await envoy.setup()
+    await envoy.authenticate("username", "password")
+    await envoy.probe()
+    # assert data
+
+    stats = envoy.probe_request.retry.statistics
+    assert "attempt_number" in stats
+    print(f"--stats--{stats}")
+    assert stats["attempt_number"] == 3
+
+    data = await envoy.update()
+    assert data
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_noconnection_at_update_with_7_6_175_standard():
+    """Test 3 network error failures at start"""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+    version = "7.6.175_standard"
+    _start_7_firmware_mock()
+    prep_envoy(version, info=True)
+
+    envoy = Envoy("127.0.0.1")
+    # remove the waits between retries for this test and set known retries
+    envoy.request.retry.wait = wait_none()
+    envoy.request.retry.stop = stop_after_attempt(3) | stop_after_delay(50)
+
+    await envoy.setup()
+    await envoy.authenticate("username", "password")
+
+    # Ensure that there were no retries.
+    stats: dict[str, Any] = envoy._firmware._get_info.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 1
+
+    await envoy.probe()
+
+    stats = envoy.probe_request.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 1
+
+    respx.get("/api/v1/production").mock().side_effect = [
+        httpx.TimeoutException("Test timeoutexception"),
+        httpx.TimeoutException("Test timeoutexception"),
+        httpx.TimeoutException("Test timeoutexception"),
+    ]
+
+    with pytest.raises(httpx.TimeoutException):
+        await envoy.update()
+
+    stats = envoy.request.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 3
+
+    respx.get("/api/v1/production").mock().side_effect = [
+        httpx.RemoteProtocolError("Test timeoutexception"),
+        httpx.RemoteProtocolError("Test timeoutexception"),
+        httpx.RemoteProtocolError("Test timeoutexception"),
+    ]
+
+    with pytest.raises(httpx.RemoteProtocolError):
+        await envoy.update()
+
+    stats = envoy.request.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 3
+
+    respx.get("/api/v1/production").mock().side_effect = [
+        httpx.NetworkError("Test timeoutexception"),
+        httpx.NetworkError("Test timeoutexception"),
+        httpx.NetworkError("Test timeoutexception"),
+    ]
+
+    with pytest.raises(httpx.NetworkError):
+        await envoy.update()
+
+    stats = envoy.request.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 3
+
+    respx.get("/api/v1/production").mock().side_effect = [
+        orjson.JSONDecodeError("Test timeoutexception", "that.file", 22),
+        orjson.JSONDecodeError("Test timeoutexception", "that.file", 22),
+        orjson.JSONDecodeError("Test timeoutexception", "that.file", 22),
+    ]
+
+    with pytest.raises(orjson.JSONDecodeError):
+        await envoy.update()
+
+    stats = envoy.request.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 3
+
+    # other error EnvoyAuthenticationRequired should end cycle
+    respx.get("/api/v1/production").mock().side_effect = [
+        httpx.NetworkError("Test timeoutexception"),
+        EnvoyAuthenticationRequired("Test timeoutexception"),
+        httpx.NetworkError,
+    ]
+
+    with pytest.raises(EnvoyAuthenticationRequired):
+        await envoy.update()
+
+    stats = envoy.request.retry.statistics
+    assert "attempt_number" in stats
+    assert stats["attempt_number"] == 2


### PR DESCRIPTION
# Proposed Change
When Envoy becomes unreachable (All connection attempts failed) the requests retry for-ever and setup, probe and update methods never return.

This pr re-configures the tenacity retry decorator to use a stop condition for maximum time since first request attempt.

- add max_request_delay parameter to Envoy and Firmware setups so time-out can be specified by caller
- Add MAX_REQUEST_DELAY with value 50 to const.py as default value
- Catch RetryError exception and return as EnvoyCommunicationError for Firmware, probe and update methods

The retry decorator has been replaced by a construct that allows using the max_request_delay. This can probably be done in a more python way. MyPy didn't like it either, hence the use of if not TYPE_CHECKING. It seemed the only option for a configurable value, if we want such a thing, which I would vote for.

# Retry Aspects
The existing retries were missing a stop condition which is the root cause of the issue. Simply implementing stop conditions seems the simple solution, but there's something to understand about the effect of the use. 

The retries are implemented 1 level above the httpx request and control the repeat of the requests. The max_request_delay is checked upon failure of a request. If enough time is left, another request is done until time is exceeded. The request itself utilizes a httpx timeout, default 10 sec setup, 60 sec read and 10 sec write.  Retry interval has some randomness with a maximum of 5 sec. 

With the chosen default of 50 sec, failure on setup will be repeated some 10-20 times times until the 50 sec is exceeded. When a read timeout occurs there will be no repeat as that took already 60 sec at the end of which the 50 sec is surpassed already. This effectively destroys the repeat for read time-outs.

# Probe behavior
Probe is collecting all known endpoints to decide what endpoints should be used in update. The logic is such that with a failure the active probe is aborted and the next one is started. If the connection is lost while probe is active, each of the individual endpoints still to probe will take the 50 sec max_request_delay. This can take anywhere up to 500 sec  for 10 endpoints.

This logic is currently unchanged as chances are low, but not zero, that this will happen right after the firmware is collected successfully.

# Error status
When using the code with a test client the error `httpx.ConnectError: All connection attempts failed` is resignalled by the retry when the Envoy is unplugged from the network.

When testing with Home Assistant no such error  was returned. Instead an anyio.EndOfStream error was returned. For now that error is caught and returned as EnvoyCommunicationError for the coordinator signal the error in a single log line rather then a stack dump.


# To decide
- This PR has a solution for the actual issue, but behavior should be understood to decide if it is the right solution.
- Probe logic may need revision too to prevent it endless going on after first failure. 
- Decide if 50 sec is the right default value
- The issue with the anyio.EndOfStream error returned when testing with HA needs assessment. 
- Should retry resignal the original error or return RetryError?
- Are we introducing some breaking change with read timeout repeat no longer effectively present?