### PR TITLE
docs: let readthedocs use virtualenv for build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ build:
       # Install poetry
       - pip install poetry
       # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
+      - poetry config virtualenvs.create true
     post_install:
       # Install dependencies
       - poetry install --with docs


### PR DESCRIPTION
ReadTheDocs errors in the build process. (https://github.com/pyenphase/pyenphase/issues/147)

```txt
ModuleNotFoundError: No module named 'myst_parser'
```

The log shows it's installing the myst parser. This is just running the build in a virtual environment to see if that solves the issue.


