### PR TITLE
docs: use new format to specify virtual env for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,11 +13,12 @@ build:
     post_create_environment:
       # Install poetry
       - pip install poetry
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create true
+
     post_install:
       # Install dependencies
-      - poetry install --with docs
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
 # Build documentation in the docs directory with Sphinx
 sphinx:


### PR DESCRIPTION
ReadTheDocs changed way to specify virtual environments recently. Using new format to see if it resolves the build failures, see  #147.