### PR TITLE
chore(deps): replace deprecated httpx data with content

### DIFF
--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -239,7 +239,7 @@ class Envoy:
                 follow_redirects=True,
                 auth=self.auth.auth,
                 timeout=self._timeout,
-                data=orjson.dumps(data),
+                content=orjson.dumps(data),
             )
         else:
             _LOGGER.debug("Requesting %s with timeout %s", url, self._timeout)


### PR DESCRIPTION
Httpx  is signalling deprecation warning 
```txt
/home/arie/dev/pyenphase/.venv/lib/python3.12/site-packages/httpx/_content.py:202: DeprecationWarning: Use 'content=<...>' to upload raw bytes/text content.
warnings.warn(message, DeprecationWarning)
```

triggered by https://github.com/pyenphase/pyenphase/blob/main/src/pyenphase/envoy.py#L242.

change to  `content=orjson.dumps(data)`

Mentioned in https://www.python-httpx.org/compatibility/#request-content

Needs testing with Envoy as my plain vanilla one doesn't allow any puts.