### PR TITLE
chore(deps): remove deprecated cookies on request

### DIFF
--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -235,7 +235,6 @@ class Envoy:
                 method if method else "POST",
                 url,
                 headers={**DEFAULT_HEADERS, **self.auth.headers},
-                cookies=self.auth.cookies,
                 follow_redirects=True,
                 auth=self.auth.auth,
                 timeout=self._timeout,
@@ -246,7 +245,6 @@ class Envoy:
             response = await self._client.get(
                 url,
                 headers={**DEFAULT_HEADERS, **self.auth.headers},
-                cookies=self.auth.cookies,
                 follow_redirects=True,
                 auth=self.auth.auth,
                 timeout=self._timeout,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -147,6 +147,10 @@ async def test_known_users_with_3_9_36_firmware(username: str, password: str) ->
     await envoy.setup()
     await envoy.authenticate(username, password)
 
+    # test cookies function now cookies are not on request
+    used_cookies = getattr(envoy.auth, "cookies")
+    assert used_cookies == {}
+
     data = await envoy.update()
     assert data
 
@@ -345,6 +349,9 @@ async def test_token_with_7_6_175_standard() -> None:
     assert isinstance(envoy.auth, EnvoyTokenAuth)
     assert envoy.auth.expire_timestamp == 1707837780
     assert envoy.auth.token == token
+
+    # test cookies function now cookies are not on request
+    assert envoy.auth.cookies == {}
 
     # execute refresh code cov
     await envoy.auth.refresh()


### PR DESCRIPTION
Httpx is signalling deprecation warning

```txt
/home/arie/dev/pyenphase/.venv/lib/python3.12/site-packages/httpx/_client.py:1559: DeprecationWarning: Setting per-request cookies=<...> is being deprecated, because the expected behavior on cookie persistence is ambiguous. Set cookies directly on the client instance instead.
warnings.warn(message, DeprecationWarning)
```
Described here: https://www.python-httpx.org/compatibility/ under header cookies.

Removed `cookies=` from get and put requests. Same cookies are in client received during jwt.
Added retrieval of cookies to test_auth to sustain cov.

Needs testing with Envoy for put. Get tested on my plain vanilla Envoy.