### PR TITLE
refactor: extend fixture_collector with cmdline args and option to read HA config file

### DIFF
--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -64,6 +64,7 @@ class SupportedFeatures(enum.IntFlag):
     DUALPHASE = 256  #: Envoy metered is configured in split phase mode
     THREEPHASE = 512  #: Envoy metered is configured in three phase mode
     CTMETERS = 1024  #: Envoy has enabled CT meter(s)
+    GENERATOR = 2048 #: Envoy reports generator data
 
 
 class PhaseNames(enum.StrEnum):

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -49,6 +49,7 @@ from .updaters.api_v1_production import EnvoyApiV1ProductionUpdater
 from .updaters.api_v1_production_inverters import EnvoyApiV1ProductionInvertersUpdater
 from .updaters.base import EnvoyUpdater
 from .updaters.ensemble import EnvoyEnembleUpdater
+from .updaters.generator import EnvoyGeneratorUpdater
 from .updaters.meters import EnvoyMetersUpdater
 from .updaters.production import (
     EnvoyProductionJsonFallbackUpdater,
@@ -73,6 +74,7 @@ UPDATERS: list[type["EnvoyUpdater"]] = [
     EnvoyApiV1ProductionInvertersUpdater,
     EnvoyEnembleUpdater,
     EnvoyTariffUpdater,
+    EnvoyGeneratorUpdater,
 ]
 
 

--- a/src/pyenphase/updaters/generator.py
+++ b/src/pyenphase/updaters/generator.py
@@ -1,0 +1,50 @@
+import logging
+from typing import Any
+
+from ..const import (
+    ENSEMBLE_MIN_VERSION,
+    URL_GEN_CONFIG,
+    SupportedFeatures,
+)
+from ..exceptions import ENDPOINT_PROBE_EXCEPTIONS
+from ..models.envoy import EnvoyData
+from .base import EnvoyUpdater
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EnvoyGeneratorUpdater(EnvoyUpdater):
+    """Class to handle updates for Generator information."""
+
+    async def probe(
+        self, discovered_features: SupportedFeatures
+    ) -> SupportedFeatures | None:
+        """Probe the Envoy for this updater and return SupportedFeatures."""
+        if self._envoy_version < ENSEMBLE_MIN_VERSION:
+            _LOGGER.debug("Firmware too old for Ensemble support")
+            return None
+
+        # Check for generator support
+        try:
+            result = await self._json_probe_request(URL_GEN_CONFIG)
+        except ENDPOINT_PROBE_EXCEPTIONS as e:
+            _LOGGER.debug("Generator config endpoint not found: %s", e)
+        else:
+            if not result or "error" in result or "err" in result:
+                # Newer firmware with no generator configured returns an empty dict
+                _LOGGER.debug("No generator found")
+                return None
+
+            self._supported_features |= SupportedFeatures.GENERATOR
+
+        return self._supported_features
+
+    async def update(self, envoy_data: EnvoyData) -> None:
+        """Update the generator data if supported."""
+        supported_features = self._supported_features
+
+        if supported_features & SupportedFeatures.GENERATOR:
+            generator_config_data: list[dict[str, Any]] = await self._json_request(
+            URL_GEN_CONFIG
+        )
+        envoy_data.raw[URL_GEN_CONFIG] = generator_config_data

--- a/tests/common.py
+++ b/tests/common.py
@@ -112,6 +112,15 @@ def prep_envoy(
     else:
         respx.get("/admin/lib/tariff").mock(return_value=Response(401))
 
+    if "ivp_ss_gen_config" in files:
+        try:
+            json_data = load_json_fixture(version, "ivp_ss_gen_config")
+        except json.decoder.JSONDecodeError:
+            json_data = {}
+        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
+
 
 def updater_features(updaters: list[EnvoyUpdater]) -> dict[str, SupportedFeatures]:
     """Return the updater supported features flags"""

--- a/tests/test_ct_meters.py
+++ b/tests/test_ct_meters.py
@@ -52,6 +52,7 @@ async def test_pr111_with_7_3_466_metered_disabled_cts():
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
     respx.get("/admin/lib/tariff").mock(return_value=Response(404))
+    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
     respx.get("/ivp/meters").mock(
         return_value=Response(200, text=load_fixture(version, "ivp_meters"))
     )
@@ -105,6 +106,7 @@ async def test_pr111_with_7_6_175_with_cts():
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
     respx.get("/admin/lib/tariff").mock(return_value=Response(404))
+    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
     respx.get("/ivp/meters").mock(
         return_value=Response(200, text=load_fixture(version, "ivp_meters"))
     )
@@ -170,6 +172,7 @@ async def test_pr111_with_7_6_175_standard():
         )
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
     respx.get("/admin/lib/tariff").mock(return_value=Response(404))
     respx.get("/ivp/meters").mock(return_value=Response(200, text=""))
 
@@ -224,6 +227,7 @@ async def test_ct_data_structures_with_7_3_466_with_cts_3phase():
         )
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
     respx.get("/admin/lib/tariff").mock(return_value=Response(404))
     respx.get("/ivp/meters").mock(
         return_value=Response(200, text=load_fixture(version, "ivp_meters"))
@@ -357,6 +361,7 @@ async def test_ct_storage_with_8_2_127_with_3cts_and_battery_split():
         )
     )
     respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
     respx.get("/admin/lib/tariff").mock(return_value=Response(404))
     respx.get("/ivp/meters").mock(
         return_value=Response(200, text=load_fixture(version, "ivp_meters"))

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1100,6 +1100,15 @@ async def test_with_7_x_firmware(
     else:
         respx.get("/ivp/meters/readings").mock(return_value=Response(404))
 
+    if "ivp_ss_gen_config" in files:
+        try:
+            json_data = load_json_fixture(version, "ivp_ss_gen_config")
+        except json.decoder.JSONDecodeError:
+            json_data = {}
+        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
+
     caplog.set_level(logging.DEBUG)
 
     envoy = await get_mock_envoy()

--- a/tests/test_pre_v7_endpoints.py
+++ b/tests/test_pre_v7_endpoints.py
@@ -58,6 +58,15 @@ async def test_with_4_2_27_firmware():
     else:
         respx.get("/admin/lib/tariff").mock(return_value=Response(404))
 
+    if "ivp_ss_gen_config" in files:
+        try:
+            json_data = load_json_fixture(version, "ivp_ss_gen_config")
+        except json.decoder.JSONDecodeError:
+            json_data = {}
+        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
+
     respx.get("/ivp/meters").mock(return_value=Response(200, json=[]))
 
     envoy = await get_mock_envoy()
@@ -130,6 +139,15 @@ async def test_with_5_0_49_firmware():
         respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
     else:
         respx.get("/admin/lib/tariff").mock(return_value=Response(404))
+
+    if "ivp_ss_gen_config" in files:
+        try:
+            json_data = load_json_fixture(version, "ivp_ss_gen_config")
+        except json.decoder.JSONDecodeError:
+            json_data = {}
+        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
+    else:
+        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
 
     respx.get("/ivp/meters").mock(return_value=Response(404))
 


### PR DESCRIPTION
To simplify collection of test fixture by HA users fixture_collector is updated to read envoy ip, username, password and token from the Home Assistant core.config_entries file. With this change HA users can:

- copy fixture_collector.py to the ha config folder
- open terminal in HA
- run the fixture_collector.py and find resulting zip file in the config folder.

command line arguments have been added to control the operation of the program. In simplest format use:
```text
dshier:/config# python fixture_collector.py -r
Fixtures written to enphase-7.6.175
Zip file written to enphase-7.6.175.zip
```
Which is the format of the original version, without debug enabled and all needed information read from the HA config.

```text
dshier:/config# python fixture_collector.py -h
usage: fixture_collector.py [-h] [-d] [-v] [-c] [-l LABEL] [-r [HA_CONFIG_FOLDER]] [-e ENVOYNAME] 
[-u USERNAME] [-p PASSWORD] [-t TOKEN]

Scan Enphase Envoy for endpoint list usable for pyenphase test fixtures. Creates output folder 
envoy_<firmware>[label] with results of scan. Zips content of created folder into envoy_<firmware>[label].zip.

options:
  -h, --help            show this help message and exit
  -d, --debug           Enable debug logging
  -v, --verbose
  -c, --clean           Remove created folder, but keep zip file
  -l LABEL, --label LABEL
                        Label to append to output folder and zip file
  -r [HA_CONFIG_FOLDER], --readhaconfig [HA_CONFIG_FOLDER]
                        Read envoyname, username, password and token from HA config file. 
                        Use -c path_to_ha_config_folder. Default is current folder.
  -e ENVOYNAME, --envoyname ENVOYNAME
                        Envoy Name or IP address. Default is envoy.local
  -u USERNAME, --username USERNAME
                        Username (for Envoy or for Enphase token website)
  -p PASSWORD, --password PASSWORD
                        Password (blank or for Enphase token website)
  -t TOKEN, --token TOKEN
                        Enphase owner token or @path_to_file to read from file
```

If no commandline arguments are specified the original method of setting up environment variables for ENVOY_HOST, ENVOY_USERNAME, ENVOY_PASSWORD and ENVOY_TOKEN still applies.