### PR TITLE
fix: for fw 3.x mark production with only zero values as EnvoyPoorDataQuality error

### DIFF
--- a/src/pyenphase/exceptions.py
+++ b/src/pyenphase/exceptions.py
@@ -58,6 +58,13 @@ class EnvoyFeatureNotAvailable(EnvoyError):
     """Exception raised when the Envoy feature is not available."""
 
 
+class EnvoyPoorDataQuality(EnvoyError):
+    """Exception raised when data identifies known issues."""
+
+    def __init__(self, status: str) -> None:
+        self.status = status
+
+
 ENDPOINT_PROBE_EXCEPTIONS = (
     json.JSONDecodeError,
     httpx.HTTPError,


### PR DESCRIPTION
When Envoy running FW 3.x restart they may send all zero values with status 200 while the internals are still restoring data. Observations are there may be 2-3 minutes of zero's before the pre-restart values are restored. When using the data with Home Assistant Energy dashboard the effect is a step in production values. See #168 and https://github.com/home-assistant/core/issues/120091.

This PR adds a _validate_data step to the envoy.update method to implement a data validation step. It currently implements 1 validation rule. If major firmware version is 3 and all values in data.system_production are zero it will signal exception `EnvoyPoorDataQuality`. For Home Assistant this will continue the outage until data is restored and only have a data gap instead of  gap followed by zero values.

```txt
Error communicating with API: Data rejected on rule: FW 3.x production all zero at startup (3.9.36).
```