### PR TITLE
docs: docs gen 2, refactor authentication doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,9 +7,9 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "pyenphase"
-copyright = "2023, pyenphase"
+copyright = "2023-2024, pyenphase"
 author = "pyenphase"
-release = "1.14.0"
+release = "|release|"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/model_autodoc.md
+++ b/docs/model_autodoc.md
@@ -42,11 +42,30 @@
 ```
 
 ```{eval-rst}
+.. autoclass:: pyenphase.auth.EnvoyAuth
+  :members:
+  :undoc-members:
+  :show-inheritance:
+  :member-order: bysource
+  :class-doc-from: init
+```
+
+```{eval-rst}
 .. autoclass:: pyenphase.auth.EnvoyTokenAuth
   :members:
   :undoc-members:
   :show-inheritance:
   :member-order: bysource
+  :class-doc-from: init
+```
+
+```{eval-rst}
+.. autoclass:: pyenphase.auth.EnvoyLegacyAuth
+  :members:
+  :undoc-members:
+  :show-inheritance:
+  :member-order: bysource
+  :class-doc-from: init
 ```
 
 ```{eval-rst}

--- a/docs/usage_authentication.md
+++ b/docs/usage_authentication.md
@@ -1,19 +1,48 @@
 # Authentication
 
-Before firmware 7, authentication was based on username/password. In these cases either `Envoy` or `Installer` usernames with a blank password or a known username/password can be used. The token is not utilized. The authentication module will calculate the passwords for these 2 accounts, if left blank, based on the serial number retrieved by the setup method.
+## Introduction
+Before firmware 7, authentication was based on username/password using Digest. Either `Envoy` or `Installer` usernames with a blank password or a known username/password can be used. If the password is left blank, the authentication module will calculate the password for the 2 named accounts, based on the Envoy serial number.
 
-As of firmware 7, token based authentication is required. The authentication module can retrieve the token from the Enlighten website using the retrieved Envoy serial number and the Enlighten username and password which need to be specified. If the token is known, it can be specified and it will be used instead of obtaining one from the internet.
+As of firmware 7, token based authentication is required. The authentication module can retrieve the token from the Enlighten website using the Envoy serial number, the Enlighten username and password, which all need to be specified. If a token is known, it can be specified and it will be used instead of obtaining one from the Enlighten website. Even if a token is known, it's best practice to also specify username and password to enable automatic refresh of an expired token.
+
+Based on the firmware version retrieved from the envoy in envoy.setup(), the [envoy.authenticate](#pyenphase.Envoy.authenticate) method will determine which of the 2 authentication methods to use.
+
+This example will work with both firmware <7 and >=7. In the first case specify the local Envoy username `envoy`, in the latter case specify the Enlighten cloud credentials and the required token will be obtained from the Enlighten cloud.
+```python
+envoy = Envoy(host_ip_or_name)
+await envoy.setup()
+await envoy.authenticate(username=username, password=password)
+
+```
+
+For firmware >= 7 and a known token, specifying it will use it and skip reaching out to the Enlghten cloud.
 
 ```python
 envoy = Envoy(host_ip_or_name)
 await envoy.setup()
 await envoy.authenticate(username=username, password=password, token=token)
+```
+
+## Obtain, re-use and renew token
+
+Upon completion of the authentication, the token can be requested and stored for later reuse in authentication. At a next application startup, pass the stored token to envoy.authenticate, in addition to the username and password. Until the token is expired it can be used with each authenticate request. If the token is expired while using it in authentication, an exception [EnvoyAuthenticationError](#pyenphase.exceptions.EnvoyAuthenticationError) is returned. In that case redo the authentication without specifying a token to force getting a new one.
+
+```python
+from pyenphase import Envoy
+from pyenphase.auth import EnvoyTokenAuth
+
+token: str = "get token from some storage"
+
+envoy = Envoy(host_ip_or_name)
+await envoy.setup()
+try:
+    await envoy.authenticate(username=username, password=password, token=token)
+except EnvoyAuthenticationError as exp:
+    await envoy.authenticate(username=username, password=password)
 
 ```
 
-## Obtain and renew token
-
-Upon completion of the authentication, the token can be requested and stored for later reuse in authentication. The application should check for [token expiry](#pyenphase.auth.EnvoyTokenAuth.expire_timestamp) and request timely [renewal](#pyenphase.auth.EnvoyTokenAuth.refresh). Until the token is expired it can be used with each authenticate request.
+The application should check for [token expiry](#pyenphase.auth.EnvoyTokenAuth.expire_timestamp) and request timely [renewal](#pyenphase.auth.EnvoyTokenAuth.refresh). Make sure to store a refreshed token again, access it using the [token property](#pyenphase.auth.EnvoyTokenAuth.token).
 
 ```python
 from pyenphase import Envoy
@@ -30,15 +59,16 @@ expire_time = envoy.auth.expire_timestamp
 
 if expire_time < (datetime.now() - timedelta(days=7)):
     await self.envoy.auth.refresh()
-
-token = envoy.auth.token
-# save token in some storage
+    token = envoy.auth.token
+    # save token in some storage for later re-use
 
 ```
 
+Enlighten user accounts can be type 'owner' or 'installer'. Token lifetime for an owner account is 1 year, while installer lifetime is 12 hours.
+
 ## Re-Authentication
 
-When authentication is omitted or data requests experience an authorization failure (401 or 403) an `EnvoyAuthenticationRequired` error is returned. When this occurs, authentication should be repeated.
+When authentication is omitted or data requests experience an authorization failure (HTTP status 401 or 403) an [EnvoyAuthenticationRequired](#pyenphase.exceptions.EnvoyAuthenticationRequired) error is returned. When this occurs, authentication should be repeated.
 
 ```python
     try:
@@ -48,24 +78,11 @@ When authentication is omitted or data requests experience an authorization fail
         await envoy.authenticate(username=username, password=password,token=token)
 ```
 
-## Authorization levels
+## Authentication over firmware update
 
-Enphase accounts are either home-owner or installer/DIY accounts. The Home owner account provides access to the data information endpoints. The installer account has in addition access to configuration and setup endpoints as well [^2]. The authentication class provides the methods `is_consumer` and `manager_token` to determine the nature of the account.
+A special case is the firmware update. These get pushed by Enphase, not frequently and not always at an expected moment. It will cause an outage of the Envoy during the patching process and an authentication error when communication is restored. Re-authentication as described above may work with existing token or it may fail and a new token would be needed. If the firmware upgrade changes from <7 to >=7, Enlighten credentials need to replace the local Envoy username/password.
 
-```python
-assert isinstance(envoy.auth, EnvoyTokenAuth)
-token = envoy.auth.token
-if envoy.auth.manager_token:
-    ...
-if envoy.auth.is_consumer:
-    ...
-```
-
-[^2]: Data provided by pyenphase is only sourced from endpoints that allow access by at least Home owner accounts. The Envoy [Request method](#pyenphase.Envoy.request) allows access to [additional endpoints](./advanced.md#bring-your-own-endpoint), provided the user account has the required authorization level.
-
-### Authentication over firmware update
-
-A special case of Envoy outage is the firmware update. These get pushed by Enphase, not frequently and not always at an expected moment. It will cause an outage of the Envoy during the patching process and an authentication error when communication is restored. Re-authentication as described above may work with existing token or it may fail and a new token would be needed. Furthermore the firmware version has changed and it may have impact on behavior. The Firmware version is only obtained in the setup method of the Envoy, this needs a repeat as well in this case.
+Furthermore the firmware version has changed and it may have impact on behavior. The Firmware version is only obtained in the setup method of the Envoy, this needs a repeat as well in this case.
 
 ```python
 from pyenphase import Envoy, EnvoyData
@@ -81,15 +98,33 @@ while True:
         data: EnvoyData = await envoy.update()
 
     except EnvoyAuthenticationRequired:
+        # is token expired. if so refresh
         expire_time = envoy.auth.expire_timestamp
         if expire_time < now.timestamp():
             await self.envoy.auth.refresh()
         else:
             # potential outage, get firmware
             await envoy.setup()
-            # authenticate without token to get new one
-            await envoy.authenticate(username=username, password=password)
             # if firmware changed on us force re-init of data updaters
             if firmware != envoy.firmware:
+                # authenticate without token to get new one
+                await envoy.authenticate(username=username, password=password)
+                # re-init communication based on new firmware
                 envoy.probe()
 ```
+
+## Authorization levels
+
+Enphase accounts are either home-owner or DIY/installer accounts. The Home owner account provides access to the data information endpoints. The DIY/installer accounts have in addition access to configuration and setup endpoints as well [^2]. The authentication class provides the property `token_type` to determine the nature of the account. This returns `owner` or `installer` based on the token type.
+
+```python
+assert isinstance(envoy.auth, EnvoyTokenAuth)
+token = envoy.auth.token
+if envoy.auth.token_type == "user":
+    ...
+else:
+    ...
+```
+
+[^2]: Data provided by pyenphase is only sourced from endpoints that allow access by at least Home owner accounts. The Envoy [Request method](#pyenphase.Envoy.request) allows access to [additional endpoints](./advanced.md#bring-your-own-endpoint), provided the user account has the required authorization level.
+

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -128,7 +128,22 @@ class Envoy:
         password: str | None = None,
         token: str | None = None,
     ) -> None:
-        """Authenticate to the Envoy based on firmware version."""
+        """Authenticate to the Envoy based on firmware version.
+
+        If firmware version retrieved in Envoy.setup is < 7 then create DigestAuth using
+        passed username and password. Use 'envoy' or 'installer' username and blank password.
+
+        If Firmware is >= 7 create JWT Token based authorization. If token is passed, use
+        it for authorization. If no token is passed, username and password should be
+        Enlighten Cloud credentials to obtain a token. Validate the token with the local Envoy.
+
+        :param username: Enligthen Cloud username or local Envoy username, defaults to None
+        :param password: Enligthen Cloud password or local Envoy password, defaults to None
+        :param token: Token to use with authentication, defaults to None
+        :raises EnvoyAuthenticationRequired: Authentication failed with the local Envoy,
+            provided token is expired or no token could be obtained from Enlighten cloud 
+            due to error or missing parameters.
+        """
         if self._firmware.version < AUTH_TOKEN_MIN_VERSION:
             # Envoy firmware using old envoy/installer authentication
             _LOGGER.debug(

--- a/src/pyenphase/exceptions.py
+++ b/src/pyenphase/exceptions.py
@@ -24,14 +24,27 @@ class EnvoyFirmwareFatalCheckError(EnvoyError):
 
 
 class EnvoyAuthenticationError(EnvoyError):
-    """Exception raised when unable to query the Envoy firmware version."""
+    """Exception raised when Envoy Authentication fails.
+
+    - When a jwt token authentication failure occurs with the local Envoy.
+    - When using token authentication and no cloud credentials or envoy serial are specified
+    - When a failure occurs during obtaining a token from the Enlighten cloud
+
+    :param status: Error status description 
+    """
 
     def __init__(self, status: str) -> None:
         self.status = status
 
 
 class EnvoyAuthenticationRequired(EnvoyError):
-    """Exception raised when authentication hasn't been setup."""
+    """Exception raised when authentication hasn't been setup.
+
+    - When communication with Envoy was attempted without setting up authentication.
+    - When neither token nor username and/or password are specified during authentication.
+
+    :param status: Error status description 
+    """
 
     def __init__(self, status: str) -> None:
         self.status = status


### PR DESCRIPTION
Docs gen 2, revisiting the docs where I left it last year. Docs gen 2 will heavily rely on Docstrings to build the detailed documentation. This will change the [Data & Reference](https://pyenphase.readthedocs.io/en/latest/index.html) section from a list of bare minimal information to a usage guideline.

No effective code changes, only Docstrings added or changed.

This PR has refactors the Authentication section of the documentation.

- Add EnvoyAuth and EnvoyLegacyAuth to the `model_autodoc.md` class list to include these in the docs
- In model_autodoc.md add  `:class-doc-from: init` for the 3 Auth classes, so class documentation for these is build from the \_\_init\_\_ docstring
- Add Docstring to all Auth.py members, including the \_\_init\_\_ modules
- Add Docstring to the exceptions.py which are used in Auth.py
- Add Docstring to envoy.authorize
- Refactor descriptive text in usage_authentication.md
