### PR TITLE
docs: refactor envoy class documentation using docstrings

### DIFF
--- a/docs/model_autodoc.md
+++ b/docs/model_autodoc.md
@@ -39,6 +39,7 @@
   :undoc-members:
   :show-inheritance:
   :member-order: bysource
+  :class-doc-from: init
 ```
 
 ```{eval-rst}

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -77,20 +77,42 @@ UPDATERS: list[type["EnvoyUpdater"]] = [
     EnvoyEnembleUpdater,
     EnvoyTariffUpdater,
     EnvoyGeneratorUpdater,
-]
+]  #: Ordered list of standard updaters for Envoy data collection
 
 
 def register_updater(updater: type[EnvoyUpdater]) -> Callable[[], None]:
-    """Register an updater."""
+    """Register an updater in the updaters list.
+
+    Registers a callable updater at the end of the updaters list. Probe
+    method of the registered updater will be called during Envoy.probe().
+
+    Use the returned callable to remove the registered updater again.
+
+    After registering or removing an updater, use Envoy.probe() to make
+    the change effective.
+
+    :param updater: callable of (sub-) class EnvoyUpdater
+    :return: callable to remove the updater from the registration list
+    """
     UPDATERS.append(updater)
 
     def _remove_updater() -> None:
+        """Callable to remove a prior registered updater.
+        """
         UPDATERS.remove(updater)
 
     return _remove_updater
 
 
 def get_updaters() -> list[type[EnvoyUpdater]]:
+    """Return list of registered updaters.
+
+    Returns current list of registered updaters. Changes
+    to the list will not be in effect until
+    Envoy.probe() is used.
+
+    :return: list of callable updaters
+    """
     return UPDATERS
 
 
@@ -103,7 +125,31 @@ class Envoy:
         client: httpx.AsyncClient | None = None,
         timeout: float | httpx.Timeout | None = None,
     ) -> None:
-        """Initialize the Envoy class."""
+        """Class for communicating with an envoy.
+
+        Collects solar production data for all Envoy models as of
+        firmware 3.9. Depending on model and installed components
+        can collect power/energy consumption, battery charge,
+        discharge and settings. Supports communication with both
+        pre- and post V7 Envoy firmware.
+
+        .. code-block:: python
+
+            envoy = Envoy(host_ip_or_name)
+            await envoy.setup()
+            await envoy.authenticate(
+                username=username, 
+                password=password, 
+                token=token
+            )
+            await envoy.update()
+
+        :param host: Envoy DNS name or IP address
+        :param client: httpx Asyncclient not veryfying SSL 
+            certificates, if not specified one will be created.
+        :param timeout: httpx Timeout to use, if not specified 
+            10 sec connection and 45 sec read timeouts will be used.
+        """
         # We use our own httpx client session so we can disable SSL verification (Envoys use self-signed SSL certs)
         self._timeout = timeout or LOCAL_TIMEOUT
         self._client = client or httpx.AsyncClient(
@@ -119,7 +165,21 @@ class Envoy:
         self._common_properties: CommonProperties = CommonProperties()
 
     async def setup(self) -> None:
-        """Obtain the firmware version for later Envoy authentication."""
+        """Initiate Envoy communication by obtaining firmware version.
+
+        Read /info on Envoy, accessible withouth authentication.
+        Instantiates EnvoyFirmware class object. Required to
+        decide what authentication to use for sub-sequent Envoy
+        communication. Use this method as first step after class instantiation
+
+        Will retry up to 4 times or 50 sec elapsed at next try, which
+        ever comes first.
+
+        :raises EnvoyFirmwareFatalCheckError: if connection or timeout
+            failure occurs
+        :raises EnvoyFirmwareCheckError: on http errors or any HTTP
+            status other then 200
+        """
         await self._firmware.setup()
 
     async def authenticate(
@@ -186,9 +246,18 @@ class Envoy:
         reraise=True,
     )
     async def probe_request(self, endpoint: str) -> httpx.Response:
-        """Make a probe request.
+        """Make a probe request to the Envoy.
 
-        Probe requests are not retried on bad JSON responses.
+        Probe requests are intended for use  by updatres during initial 
+        search of available features in the Envoy. They are not retried 
+        on connection errors, timeouts or bad JSON responses. 
+        For regular data retrieval, use the request method. 
+        Sends GET request to endpoint on Envoy and returns the response.
+
+        :param endpoint: Envoy Endpoint to access, start with leading /.
+        :raises EnvoyAuthenticationRequired: if no prior authentication
+            was completed or HTTP status 401 or 404 is returned.
+        :return: request response.
         """
         return await self._request(endpoint)
 
@@ -211,7 +280,22 @@ class Envoy:
     ) -> httpx.Response:
         """Make a request to the Envoy.
 
-        Request retries on bad JSON responses which the Envoy sometimes returns.
+        Send GET or POST request to Envoy. Defaults to GET, specify
+        data dictionary to perform a POST. Only specify the endpoint
+        path in the Envoy, HTTP type and Envoy address is prepended
+        to form full URL based on authentication method.
+
+        Request retries on bad JSON responses which the Envoy sometimes
+        returns, on network errors, timeouts and remote protocol errors.
+        Will retry up to 4 times or 50 sec elapsed at next try, which
+        ever comes first.
+
+        :param endpoint: Envoy Endpoint to access, start with leading /
+        :param data: data dictionary to send to the Envoy, defaults to None
+        :raises EnvoyAuthenticationRequired: if no prior authentication
+            was completed or HTTP status 401 or 404 is returned.
+        :raises: Any communication errors when retries are exceeded
+        :return: request response.
         """
         return await self._request(endpoint, data)
 
@@ -221,7 +305,20 @@ class Envoy:
         data: dict[str, Any] | None = None,
         method: str | None = None,
     ) -> httpx.Response:
-        """Make a request to the Envoy."""
+        """Make a request to the Envoy.
+
+        If data is specified use POST or specified method to
+        send data dictionary as json string to the endpoint.
+        If no data is specified use GET request. Return the response.
+
+        :param endpoint: Envoy Endpoint to access, start with leading /
+        :param data: data dictionary to send to the Envoy, defaults to None
+        :param method: method to use to send data dictionary,
+            POST if none, only used for data send
+        :raises EnvoyAuthenticationRequired: if no prior authentication
+            was completed or HTTP status 401 or 404 is returned
+        :return: request response
+        """
         if self.auth is None:
             raise EnvoyAuthenticationRequired(
                 "You must authenticate to the Envoy before making requests."
@@ -280,75 +377,90 @@ class Envoy:
 
     @property
     def host(self) -> str:
-        """Return the Envoy host."""
+        """Return the Envoy host specified at initialization."""
         return self._host
 
     @property
     def firmware(self) -> AwesomeVersion:
-        """Return the Envoy firmware version."""
+        """Return the Envoy firmware version as read from the Envoy."""
         return self._firmware.version
 
     @property
     def part_number(self) -> str | None:
-        """Return the Envoy part number."""
+        """Return the Envoy part number as read from the Envoy."""
         return self._firmware.part_number
 
     @property
     def serial_number(self) -> str | None:
-        """Return the Envoy serial number."""
+        """Return the Envoy serial number as read from the Envoy."""
         return self._firmware.serial
 
     @property
     def supported_features(self) -> SupportedFeatures:
-        """Return the supported features."""
+        """Return the mask of Envoy supported features as established during Probe."""
         assert self._supported_features is not None, "Call setup() first"  # nosec
         return self._supported_features
 
     @property
     def phase_count(self) -> int:
-        """Return the number of configured phases for CT meters."""
+        """Return the number of configured phases for CT meters as read from the Envoy."""
         assert self._common_properties is not None, "Call setup() first"  # nosec
         return self._common_properties.phase_count
 
     @property
     def active_phase_count(self) -> int:
-        """Return the number of phases reported in production/consumption report."""
+        """Return the number of actual reported phases in Envoy production/consumption report."""
         assert self._common_properties is not None, "Call setup() first"  # nosec
         return self._common_properties.active_phase_count
 
     @property
     def ct_meter_count(self) -> int:
-        """Return the number of configured current transformers (CT)"""
+        """Return the number of configured current transformers (CT) as read from the Envoy"""
         assert self._common_properties is not None, "Call setup() first"  # nosec
         return self._common_properties.ct_meter_count
 
     @property
     def consumption_meter_type(self) -> CtType | None:
-        """Return the type of consumption ct meter installed (total or net consumption or None)."""
+        """Return the type of consumption ct meter installed (total
+        or net-consumption or None) as read from the Envoy."""
         assert self._common_properties is not None, "Call setup() first"  # nosec
         return self._common_properties.consumption_meter_type
 
     @property
     def production_meter_type(self) -> CtType | None:
-        """Return the type of production ct meter installed (Production or None)."""
+        """Return the type of production ct meter installed 
+        (Production or None) as read from the Envoy."""
         assert self._common_properties is not None, "Call setup() first"  # nosec
         return self._common_properties.production_meter_type
 
     @property
     def storage_meter_type(self) -> CtType | None:
-        """Return the type of storage ct meter installed (Storage or None)."""
+        """Return the type of storage ct meter installed (Storage or None) as read from the Envoy."""
         assert self._common_properties is not None, "Call setup() first"  # nosec
         return self._common_properties.storage_meter_type
 
     @property
     def phase_mode(self) -> EnvoyPhaseMode | None:
-        """Return the phase mode configured for the CT meters (single, split or three)."""
+        """Return the phase mode configured for the CT meters (single, split or three) as read from the Envoy."""
         assert self._common_properties is not None, "Call setup() first"  # nosec
         return self._common_properties.phase_mode
 
     @cached_property
     def envoy_model(self) -> str:
-        """Return Envoy model description."""
+        """Return Envoy model description.
+
+        Describes the Envoy model based on properties found.
+
+        - if 2 or more phases found or at least 1 ct is found:
+        - -  phase count
+        - -  phase mode
+        - if consumption CT found, type of consumption CT
+        - presence of production and/or storage ct
+
+        Example: "Envoy, phases: 2, phase mode: split, net-consumption CT, production CT"
+
+        :return: String describing the Envoy model and features.
+        """
         model = "Envoy"
 
         # if CT and more then 1 phase add phase count to model
@@ -387,7 +499,23 @@ class Envoy:
         return response
 
     async def probe(self) -> None:
-        """Probe for model and supported features."""
+        """Probe for Envoy model and supported features.
+
+        For each updater in the list of updaters returned by get_updaters,
+        execute the probe() method. Build and store a list of updaters to use,
+        containing updaters for which the probe() method does return at least 1
+        supported feature. Store the map of all returned supported features.
+
+        An updaters probe method should determine if the data for the specific
+        updater scope is available or not. If so, the updaters update() method will
+        be used during data collection.
+
+        Probe should be used only once, after setup and authorization at the start of
+        the communication. The update() method will call probe if not done prior.
+
+        :raises EnvoyProbeFailed: if no solar production data can be found on the Envoy.
+            Solar production data is available in all Envoy models.
+        """
         supported_features = SupportedFeatures(0)
         updaters: list[EnvoyUpdater] = []
         version = self._firmware.version
@@ -411,7 +539,20 @@ class Envoy:
         self._supported_features = supported_features
 
     def _validate_update(self, data: EnvoyData) -> None:
-        """Perform some overall validation checks and raise for issues."""
+        """Perform some overall validation checks and raise for issues.
+
+        Envoy data returned can be impacted by the state of the Envoy. This
+        validates searches for known cases and rules the data as invalid.
+        INtention is to avoid false data reported and have it rather signalled
+        as poor quality.
+
+        - Envoy firmware v3 starts communicating before all data is established
+            and sends zero values for solar production during first minutes
+            after startup. Signal poor data quality as long as all values are 0.
+
+        :param data: Envoy data
+        :raises EnvoyPoorDataQuality: data was deemed invalid based on specific quality tests
+        """
         if self._firmware.version.major == "3" and data.system_production:
             # FW R3.x will return status 200 with all zeros right after startup
             # where never versions return status 503 to signal not ready yet
@@ -429,7 +570,20 @@ class Envoy:
                 )
 
     async def update(self) -> EnvoyData:
-        """Update data."""
+        """Read data from Envoy.
+
+        For each updater in the list of established updaters during probe(),
+        execute the update() method to collect current data from the Envoy.
+        If probe was never executed, use probe method first.
+
+        An updaters update() method should obtain the data for the specific
+        updater scope and save to the Envoy data set.
+
+        :raises EnvoyCommunicationError: when EndOfStream is reported during communication.
+        :raises EnvoyCommunicationError: when httpx network or communication error occurrs.
+        :raises EnvoyHTTPStatusError: when HTTP status is not 2xx.
+        :return: Collected Envoy data
+        """
         # Some of the updaters user the same endpoint
         # so we cache the 200 responses for each update
         # cycle to not make duplicate requests
@@ -455,12 +609,30 @@ class Envoy:
     async def _json_request(
         self, end_point: str, data: dict[str, Any] | None, method: str | None = None
     ) -> Any:
-        """Make a request to the Envoy and return the JSON response."""
+        """Make a request to the Envoy and return the JSON response.
+
+        Uses _request() to obtain response and returns response content
+        as formatted JSON.
+
+        :param endpoint: Envoy Endpoint to access, start with leading /
+        :param data: data dictionary to send to the Envoy, defaults to None
+        :param method: method to use to send data dictionary,
+            POST if none, only used for data send
+        :return: response content as JSON
+        """
         response = await self._request(end_point, data, method)
         return json_loads(end_point, response.content)
 
     async def go_on_grid(self) -> dict[str, Any]:
-        """Make a request to the Envoy to go on grid."""
+        """Make a request to the Envoy to go on grid.
+
+        POST {"mains_admin_state": "closed"} to /ivp/ensemble/relay directing
+        to connect to the grid. Requires ENPOWER installed.
+
+        :raises EnvoyFeatureNotAvailable: If ENPOWER feature is not available in Envoy
+        :raises EnvoyHTTPStatusError: when HTTP status is not 2xx.
+        :return: JSON returned by Envoy
+        """
         if not self.supported_features & SupportedFeatures.ENPOWER:
             raise EnvoyFeatureNotAvailable(
                 "This feature is not available on this Envoy."
@@ -468,7 +640,15 @@ class Envoy:
         return await self._json_request(URL_GRID_RELAY, {"mains_admin_state": "closed"})
 
     async def go_off_grid(self) -> dict[str, Any]:
-        """Make a request to the Envoy to go off grid."""
+        """Make a request to the Envoy to go off grid.
+
+        POST {"mains_admin_state": "open"} to /ivp/ensemble/relay directing
+        to disconnect from the grid. Requires ENPOWER installed.
+
+        :raises EnvoyFeatureNotAvailable: If ENPOWER feature is not available in Envoy
+        :raises EnvoyHTTPStatusError: when HTTP status is not 2xx.
+        :return: JSON returned by Envoy
+        """
         if not self.supported_features & SupportedFeatures.ENPOWER:
             raise EnvoyFeatureNotAvailable(
                 "This feature is not available on this Envoy."
@@ -476,7 +656,37 @@ class Envoy:
         return await self._json_request(URL_GRID_RELAY, {"mains_admin_state": "open"})
 
     async def update_dry_contact(self, new_data: dict[str, Any]) -> dict[str, Any]:
-        """Update settings for an Enpower dry contact relay."""
+        """Update settings for an Enpower dry contact relay.
+
+        POST updated dry contact settings to /ivp/ss/dry_contact_settings
+        in the Envoy. New_data dict can contain one or more of below items
+        to set. The key/value for "id" is required to identify the relay.
+        Only include key/values to change.
+
+        .. code-block:: json
+
+            {
+                "id": "<relay-id>",
+                "grid_action": "value",
+                "micro_grid_action": "value",
+                "gen_action": "value",
+                "override": "value",
+                "load_name": "value",
+                "mode": "value",
+                "soc_low": "value",
+                "soc_high": "value",
+            },
+
+        Settings specified in the data dict are updated in the
+        internally stored dry_contact_settings and send as a whole
+        to update the Envoy.
+
+        :param new_data: dict of settings to change, "id" key/value required
+        :raises EnvoyFeatureNotAvailable: If ENPOWER feature is not available in Envoy
+        :raises ValueError: If update was attempted before first data was requested from Envoy
+        :raises ValueError: If no "id" key is present in data dict to send.
+        :return: dry_contact_settings JSON returned by Envoy
+        """
         # All settings for the relay must be sent in the POST or it may crash the Envoy
 
         if not self.supported_features & SupportedFeatures.ENPOWER:
@@ -499,7 +709,17 @@ class Envoy:
         )
 
     async def open_dry_contact(self, id: str) -> dict[str, Any]:
-        """Open a dry contact relay."""
+        """Open a dry contact relay.
+
+        POST {"dry_contacts": {"id": id, "status": "open"}} to Envoy to
+        open dry contact with specified id. Upon successful POST,
+        update dry contact status in internal data as Envoy needs some time
+        to implement the change and have status updated.
+
+        :param id: relay id of dry contact relay to open
+        :raises EnvoyFeatureNotAvailable: If ENPOWER feature is not available in Envoy
+        :return: JSON response of Envoy
+        """
         if not self.supported_features & SupportedFeatures.ENPOWER:
             raise EnvoyFeatureNotAvailable(
                 "This feature is not available on this Envoy."
@@ -516,7 +736,17 @@ class Envoy:
         return result
 
     async def close_dry_contact(self, id: str) -> dict[str, Any]:
-        """Open a dry contact relay."""
+        """Close a dry contact relay.
+
+        POST {"dry_contacts": {"id": id, "status": "closed"}} to Envoy to
+        close dry contact with specified id. Upon successful POST,
+        update dry contact status in internal data as Envoy needs some time
+        to implement the change and have status updated.
+
+        :param id: relay id of dry contact relay to open
+        :raises EnvoyFeatureNotAvailable: If ENPOWER feature is not available in Envoy
+        :return: JSON response of Envoy
+        """
         if not self.supported_features & SupportedFeatures.ENPOWER:
             raise EnvoyFeatureNotAvailable(
                 "This feature is not available on this Envoy."
@@ -533,7 +763,18 @@ class Envoy:
         return result
 
     async def enable_charge_from_grid(self) -> dict[str, Any]:
-        """Enable charge from grid for Encharge batteries."""
+        """Enable charge from grid for Encharge batteries.
+
+        Set charge_from_grid true in internal stored
+        tariff data and send updated tariff data to Envoy using PUT.
+        This will update the charge from grid setting to true
+        in the Envoy.
+
+        :raises EnvoyFeatureNotAvailable: If no Encharge or IQ batteries are available
+        :raises EnvoyFeatureNotAvailable: If no TARIFF data is available in Envoy
+        :raises ValueError: If update was attempted before first data was requested from Envoy
+        :return: JSON response of Envoy
+        """
         self._verify_tariff_storage_or_raise()
         if TYPE_CHECKING:
             assert self.data is not None  # nosec
@@ -545,7 +786,18 @@ class Envoy:
         )
 
     async def disable_charge_from_grid(self) -> dict[str, Any]:
-        """Disable charge from grid for Encharge batteries."""
+        """Disable charge from grid for Encharge batteries.
+
+        Set charge_from_grid false in internal stored
+        tariff data and send updated tariff data to Envoy using PUT.
+        This will update the charge from grid setting to false
+        in the Envoy.
+
+        :raises EnvoyFeatureNotAvailable: If no Encharge or IQ batteries are available
+        :raises EnvoyFeatureNotAvailable: If no TARIFF data is available in Envoy
+        :raises ValueError: If update was attempted before first data was requested from Envoy
+        :return: JSON response of Envoy
+        """
         self._verify_tariff_storage_or_raise()
         if TYPE_CHECKING:
             assert self.data is not None  # nosec
@@ -557,7 +809,19 @@ class Envoy:
         )
 
     async def set_storage_mode(self, mode: EnvoyStorageMode) -> dict[str, Any]:
-        """Set the Encharge storage mode."""
+        """Set the Encharge storage mode.
+
+        Set storage_mode in internal stored tariff data to specified
+        mode and send updated tariff data to /admin/lib/tariff in Envoy
+        using PUT. This will update the storage mode setting
+        in the Envoy.
+
+        :param mode: storage mode to set
+        :raises EnvoyFeatureNotAvailable: If no Encharge or IQ batteries are available
+        :raises EnvoyFeatureNotAvailable: If no TARIFF data is available in Envoy
+        :raises ValueError: If update was attempted before first data was requested from Envoy
+        :return: JSON response of Envoy
+        """
         self._verify_tariff_storage_or_raise()
         if TYPE_CHECKING:
             assert self.data is not None  # nosec
@@ -571,7 +835,19 @@ class Envoy:
         )
 
     async def set_reserve_soc(self, value: int) -> dict[str, Any]:
-        """Set the Encharge reserve state of charge."""
+        """Set the Encharge reserve state of charge.
+
+        Set reserved_soc in internal stored tariff data to specified
+        value and send updated tariff data to /admin/lib/tariff in Envoy
+        using PUT. This will update the reserve soc setting
+        in the Envoy.
+
+        :param value: reserve soc to set
+        :raises EnvoyFeatureNotAvailable: If no Encharge or IQ batteries are available
+        :raises EnvoyFeatureNotAvailable: If no TARIFF data is available in Envoy
+        :raises ValueError: If update was attempted before first data was requested from Envoy
+        :return: JSON response of Envoy
+        """
         self._verify_tariff_storage_or_raise()
         if TYPE_CHECKING:
             assert self.data is not None  # nosec
@@ -583,6 +859,12 @@ class Envoy:
         )
 
     def _verify_tariff_storage_or_raise(self) -> None:
+        """verify Encharge or IQ batteries and tariff data are available in Envoy
+
+        :raises EnvoyFeatureNotAvailable: If no Encharge or IQ batteries are available
+        :raises EnvoyFeatureNotAvailable: If no TARIFF data is available in Envoy
+        :raises ValueError: If update was attempted before first data was requested from Envoy
+        """
         if not self.supported_features & SupportedFeatures.ENCHARGE:
             raise EnvoyFeatureNotAvailable(
                 "This feature requires Enphase Encharge or IQ Batteries."

--- a/src/pyenphase/exceptions.py
+++ b/src/pyenphase/exceptions.py
@@ -1,3 +1,5 @@
+"""Enphase Envoy exceptions."""
+
 import json
 
 import httpx
@@ -8,7 +10,14 @@ class EnvoyError(Exception):
 
 
 class EnvoyFirmwareCheckError(EnvoyError):
-    """Exception raised when unable to query the Envoy firmware version."""
+    """Exception raised when unable to query the Envoy firmware version.
+
+    - http error when sending request to Envoy
+    - Any http status code other then 200 received
+
+    :param status_code: http status code
+    :param status: Error status description
+    """
 
     def __init__(self, status_code: int, status: str) -> None:
         self.status_code = status_code
@@ -16,7 +25,13 @@ class EnvoyFirmwareCheckError(EnvoyError):
 
 
 class EnvoyFirmwareFatalCheckError(EnvoyError):
-    """Exception raised when we should not retry the Envoy firmware version."""
+    """Exception raised when we should not retry getting the Envoy firmware version.
+
+    - httpx timeout or connection error when sending request to Envoy
+
+    :param status_code: http status code
+    :param status: Error status description
+    """
 
     def __init__(self, status_code: int, status: str) -> None:
         self.status_code = status_code
@@ -38,7 +53,14 @@ class EnvoyAuthenticationRequired(EnvoyError):
 
 
 class EnvoyHTTPStatusError(EnvoyError):
-    """Exception raised when unable to query the Envoy status."""
+    """Exception raised when unable to query the Envoy.
+
+    - HTTP Status of request not in 200 range.
+
+    :param status_code: http status code
+    :param status: Error status description
+    :param url: failing url
+    """
 
     def __init__(self, status_code: int, url: str) -> None:
         self.status_code = status_code
@@ -51,15 +73,29 @@ class EnvoyProbeFailed(EnvoyError):
 
 
 class EnvoyCommunicationError(EnvoyError):
-    """Exception raised when the Envoy communication fails."""
+    """Exception raised when the Envoy communication fails.
+
+    - EndOfStream is reported during communication.
+    - httpx.NetworkError error occurrs.
+    - httpx.TimeoutException error occurs
+    """
 
 
 class EnvoyFeatureNotAvailable(EnvoyError):
-    """Exception raised when the Envoy feature is not available."""
+    """Exception raised when the Envoy feature is not available.
+
+    - When using go on/off grid and ENPOWER feature is not available in Envoy
+
+    """
 
 
 class EnvoyPoorDataQuality(EnvoyError):
-    """Exception raised when data identifies known issues."""
+    """Exception raised when data identifies known issues.
+
+    - FW 3.x production values all zero at startup
+
+    :param status: Error status description
+    """
 
     def __init__(self, status: str) -> None:
         self.status = status


### PR DESCRIPTION
Docs gen 2, revisiting the docs where I left it last year. Docs gen 2 will heavily rely on Docstrings to build the detailed documentation. 

This pr will refactor the[ envoy class documentation.](https://pyenphase.readthedocs.io/en/latest/model_autodoc.html#pyenphase.Envoy)

No code changes, only Docstrings or comments added or changed in python code, along with needed markdown file changes.
