### PR TITLE
docs: refactor firmware class documentation using docstrings

### DIFF
--- a/docs/model_autodoc.md
+++ b/docs/model_autodoc.md
@@ -55,6 +55,7 @@
   :undoc-members:
   :show-inheritance:
   :member-order: bysource
+  :class-doc-from: init
 ```
 
 ```{eval-rst}


### PR DESCRIPTION
Docs gen 2, revisiting the docs where I left it last year. Docs gen 2 will heavily rely on Docstrings to build the detailed documentation.

This pr will refactor the [firmware class documentation.](https://pyenphase.readthedocs.io/en/latest/model_autodoc.html#pyenphase.firmware.EnvoyFirmware)

No code changes, only Docstrings or comments added or changed in python code, along with needed markdown file changes.