### PR TITLE
docs: refactor ssl helper documentation using docstring

### DIFF
--- a/docs/model_autodoc.md
+++ b/docs/model_autodoc.md
@@ -263,8 +263,6 @@
 
 ## SSL
 
-Helper functions for SSL
-
 ```{eval-rst}
 .. automodule:: pyenphase.ssl
   :members: NO_VERIFY_SSL_CONTEXT, SSL_CONTEXT, create_no_verify_ssl_context, create_default_ssl_context

--- a/docs/model_autodoc.md
+++ b/docs/model_autodoc.md
@@ -263,11 +263,13 @@
 
 ## SSL
 
+Helper functions for SSL
+
 ```{eval-rst}
 .. automodule:: pyenphase.ssl
-  :members:
+  :members: NO_VERIFY_SSL_CONTEXT, SSL_CONTEXT, create_no_verify_ssl_context, create_default_ssl_context
   :show-inheritance:
-  :member-order: bysource
+
 ```
 
 # Exceptions

--- a/src/pyenphase/ssl.py
+++ b/src/pyenphase/ssl.py
@@ -26,35 +26,30 @@ def create_no_verify_ssl_context() -> ssl.SSLContext:
     return sslcontext
 
 
+#: Alias for :any:`create_no_verify_ssl_context`
+#:
+#: .. code-block:: python
+#:
+#:     import httpx
+#:     from pyenphase.ssl import NO_VERIFY_SSL_CONTEXT
+#:
+#:     client = httpx.AsyncClient(verify=NO_VERIFY_SSL_CONTEXT)
 NO_VERIFY_SSL_CONTEXT = create_no_verify_ssl_context()
-"""Create httpx client with ssl verify turned off.
-
-Alias for :any:`create_no_verify_ssl_context`
-
-.. code-block:: python
-
-    import httpx
-    from pyenphase.ssl import NO_VERIFY_SSL_CONTEXT
-
-    client = httpx.AsyncClient(verify=NO_VERIFY_SSL_CONTEXT)
-"""
 
 
 def create_default_ssl_context() -> ssl.SSLContext:
-    """Return an default SSL context."""
+    """Create httpx client with default SSL context."""
     return ssl.create_default_context()
 
 
+#: Alias for :any:`create_default_ssl_context`
+#:
+#: .. code-block:: python
+#:
+#:    import httpx
+#:    from pyenphase.ssl import SSL_CONTEXT
+#:
+#:    async with httpx.AsyncClient(verify=SSL_CONTEXT) as client:
+#:        response = await client.post(url, json=json, data=data)
+#:
 SSL_CONTEXT = create_default_ssl_context()
-"""Create httpx client with default SSL context.
-
-Alias for :any:`create_default_ssl_context`
-
-.. code-block:: python
-
-    import httpx
-    from pyenphase.ssl import SSL_CONTEXT
-
-    async with httpx.AsyncClient(verify=SSL_CONTEXT) as client:
-        response = await client.post(url, json=json, data=data)
-"""

--- a/src/pyenphase/ssl.py
+++ b/src/pyenphase/ssl.py
@@ -1,4 +1,5 @@
 """Pyenphase SSL helper"""
+
 import contextlib
 import ssl
 

--- a/src/pyenphase/ssl.py
+++ b/src/pyenphase/ssl.py
@@ -1,13 +1,17 @@
+"""Pyenphase SSL helper"""
 import contextlib
 import ssl
 
 
 def create_no_verify_ssl_context() -> ssl.SSLContext:
     """Return an SSL context that does not verify the server certificate.
+
     This is a copy of aiohttp's create_default_context() function, with the
     ssl verify turned off and old SSL versions enabled.
 
     https://github.com/aio-libs/aiohttp/blob/33953f110e97eecc707e1402daa8d543f38a189b/aiohttp/connector.py#L911
+
+    :return: SSLcontext with ssl verify turned off.
     """
     sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     sslcontext.check_hostname = False
@@ -22,6 +26,17 @@ def create_no_verify_ssl_context() -> ssl.SSLContext:
 
 
 NO_VERIFY_SSL_CONTEXT = create_no_verify_ssl_context()
+"""Create httpx client with ssl verify turned off.
+
+Alias for :any:`create_no_verify_ssl_context`
+
+.. code-block:: python
+
+    import httpx
+    from pyenphase.ssl import NO_VERIFY_SSL_CONTEXT
+
+    client = httpx.AsyncClient(verify=NO_VERIFY_SSL_CONTEXT)
+"""
 
 
 def create_default_ssl_context() -> ssl.SSLContext:
@@ -30,3 +45,15 @@ def create_default_ssl_context() -> ssl.SSLContext:
 
 
 SSL_CONTEXT = create_default_ssl_context()
+"""Create httpx client with default SSL context.
+
+Alias for :any:`create_default_ssl_context`
+
+.. code-block:: python
+
+    import httpx
+    from pyenphase.ssl import SSL_CONTEXT
+
+    async with httpx.AsyncClient(verify=SSL_CONTEXT) as client:
+        response = await client.post(url, json=json, data=data)
+"""


### PR DESCRIPTION
Docs gen 2, revisiting the docs where I left it last year. Docs gen 2 will heavily rely on Docstrings to build the detailed documentation.

This pr will refactor the [ssl helper documentation.](https://pyenphase.readthedocs.io/en/latest/model_autodoc.html#module-pyenphase.ssl)

No code changes, only Docstrings or comments added or changed in python code, along with needed markdown file changes.