### PR TITLE
docs: refactor json helper documentation using docstrings

### DIFF
--- a/docs/model_autodoc.md
+++ b/docs/model_autodoc.md
@@ -253,6 +253,8 @@
 
 ## Json
 
+Helper functions for JSON.
+
 ```{eval-rst}
 .. autoclass:: pyenphase.json.json_loads
   :members:

--- a/src/pyenphase/json.py
+++ b/src/pyenphase/json.py
@@ -9,6 +9,12 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def json_loads(end_point: str, json_source: bytes | str) -> Any:
+    """deserialize a JSON string into a Python object
+
+    :param end_point: source for json, used for debug log, typically endpoint on Envoy.
+    :param json_source: json string, typically from request response content to Envoy.
+    :return: deserialized JSON
+    """
     try:
         return orjson.loads(json_source)
     except orjson.JSONDecodeError as e:


### PR DESCRIPTION
Docs gen 2, revisiting the docs where I left it last year. Docs gen 2 will heavily rely on Docstrings to build the detailed documentation.

This pr will refactor the [json helper documentation.](https://pyenphase.readthedocs.io/en/latest/model_autodoc.html#json)

No code changes, only Docstrings or comments added or changed in python code, along with needed markdown file changes.