### PR TITLE
docs: refactor const.py to use docstring for documentation.

### DIFF
--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -111,4 +111,3 @@ class PhaseNames(enum.StrEnum):
 #:         print(production[PHASENAMES[phase]])
 #:
 PHASENAMES: list[str] = list(PhaseNames)
-

--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -1,3 +1,5 @@
+"""pyenphase constant definitions"""
+
 import enum
 
 import httpx
@@ -51,15 +53,40 @@ MAX_REQUEST_ATTEMPTS = 4
 
 
 class SupportedFeatures(enum.IntFlag):
-    """Features available from Envoy"""
+    """Features available from Envoy
 
-    INVERTERS = 1  #: Envoy reports inverters
+    Each supported feature maps to a specific data set or information
+    that can be provided by an Envoy. Depending on actual make, firmware
+    and installed components an Envoy may provide 1 or more features.
+    All Envoy should at least report solar production, marked as PRODUCTION.
+
+    Class :any:`EnvoyUpdater` updaters will set these features flags
+    during the :any:`Envoy.probe` phase. During data collection by
+    :any:`Envoy.update` each updater with set features will be used to
+    collect the specific data.
+
+    .. code-block:: python
+
+        from pyenphase.const import SupportedFeatures
+
+        # set METERING flag
+        features |= SupportedFeatures.METERING
+
+        # test features
+        if features.PRODUCTION in supported_features:
+            pass
+
+        if features & SupportedFeatures.DUALPHASE:
+            pass
+    """
+
+    INVERTERS = 1  #: Envoy reports solar panel inverters
     METERING = 2  #: Envoy reports active production meter
     TOTAL_CONSUMPTION = 4  #: Envoy reports total consumption
     NET_CONSUMPTION = 8  #: Envoy reports net consumption
     ENCHARGE = 16  #: Envoy reports encharge data
     ENPOWER = 32  #: Envoy reports Enpower data
-    PRODUCTION = 64  #: Envoy reports production data
+    PRODUCTION = 64  #: Envoy reports solar production data
     TARIFF = 128  #: Envoy reports tariff information
     DUALPHASE = 256  #: Envoy metered is configured in split phase mode
     THREEPHASE = 512  #: Envoy metered is configured in three phase mode
@@ -68,9 +95,20 @@ class SupportedFeatures(enum.IntFlag):
 
 
 class PhaseNames(enum.StrEnum):
-    PHASE_1 = "L1"
-    PHASE_2 = "L2"
-    PHASE_3 = "L3"
+    """Electricity grid phase names."""
+
+    PHASE_1 = "L1"  #: first phase (1, A, ..)
+    PHASE_2 = "L2"  #: second phase (2, B, ..)
+    PHASE_3 = "L3"  #: third phase (3, C, ..)
 
 
 PHASENAMES: list[str] = list(PhaseNames)
+"""list to access :any:`PhaseNames` by numerical index.
+
+.. code-block:: python
+
+    phase_count = 2
+    for phase in range(phase_count):
+        print(production[PHASENAMES[phase]])
+
+"""

--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -102,13 +102,13 @@ class PhaseNames(enum.StrEnum):
     PHASE_3 = "L3"  #: third phase (3, C, ..)
 
 
+#: list to access :any:`PhaseNames` by numerical index.
+#:
+#: .. code-block:: python
+#:
+#:     phase_count = 2
+#:     for phase in range(phase_count):
+#:         print(production[PHASENAMES[phase]])
+#:
 PHASENAMES: list[str] = list(PhaseNames)
-"""list to access :any:`PhaseNames` by numerical index.
 
-.. code-block:: python
-
-    phase_count = 2
-    for phase in range(phase_count):
-        print(production[PHASENAMES[phase]])
-
-"""


### PR DESCRIPTION
Docs gen 2, revisiting the docs where I left it last year. Docs gen 2 will heavily rely on Docstrings to build the detailed documentation.

This pr will refactor const.py for [SupportedFeatures](https://pyenphase.readthedocs.io/en/latest/model_autodoc.html#pyenphase.const.SupportedFeatures) and [PhaseNames](https://pyenphase.readthedocs.io/en/latest/model_autodoc.html#pyenphase.const.PhaseNames) documentation.
 
No code changes, only Docstrings or comments added or changed in python code, along with needed markdown file changes.