### PR TITLE
feat: Add http method to request method parameters

### DIFF
--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -292,7 +292,10 @@ class Envoy:
         reraise=True,
     )
     async def request(
-        self, endpoint: str, data: dict[str, Any] | None = None
+        self,
+        endpoint: str,
+        data: dict[str, Any] | None = None,
+        method: str | None = None,
     ) -> httpx.Response:
         """Make a request to the Envoy.
 
@@ -307,13 +310,16 @@ class Envoy:
         ever comes first.
 
         :param endpoint: Envoy Endpoint to access, start with leading /
-        :param data: data dictionary to send to the Envoy, defaults to None
+        :param data: optional data dictionary to send to the Envoy
+            Defaults to none, if none a GET request is issued.
+        :param method: HTTP method to use when sending data dictionary,
+            if none and data is specified POST is default
         :raises EnvoyAuthenticationRequired: if no prior authentication
             was completed or HTTP status 401 or 404 is returned.
         :raises: Any communication errors when retries are exceeded
         :return: request response.
         """
-        return await self._request(endpoint, data)
+        return await self._request(endpoint, data, method)
 
     async def _request(
         self,


### PR DESCRIPTION
The envoy.request method provides a method to issue request to the Envoy. It currently does not offer an option to specify the http method like _request does. When data is specified it only allows for the POST method.

This PR adds a method parameter, defaulting to None, which is passed on to the called _request method so users can opt to use any desired method by specifying it. The default behavior of using POST with data is unchanged. 