### PR TITLE
fix: set EnvoyStorageMode to None if tariff storage_settings mode is null and causes exception None is not a valid EnvoyStorageMode.

### DIFF
--- a/src/pyenphase/models/tariff.py
+++ b/src/pyenphase/models/tariff.py
@@ -66,7 +66,7 @@ class EnvoyTariff:
 class EnvoyStorageSettings:
     """Model for the Envoy storage settings."""
 
-    mode: EnvoyStorageMode
+    mode: EnvoyStorageMode | None
     operation_mode_sub_type: str
     reserved_soc: float
     very_low_soc: int
@@ -80,10 +80,11 @@ class EnvoyStorageSettings:
             # It appears a `mode` value of `economy` and `savings-mode` is interchangeable
             # However, the Enlighten app is using the `economy` value, so we will convert
             # `savings-mode` to `economy`
+            # some fw return None in storage_settings["data"]
             mode=(
                 EnvoyStorageMode.SAVINGS
                 if data["mode"] == EnvoyStorageMode.LEGACY_SAVINGS.value
-                else EnvoyStorageMode(data["mode"])
+                else EnvoyStorageMode(data["mode"]) if data.get("mode") else None
             ),
             operation_mode_sub_type=data["operation_mode_sub_type"],
             reserved_soc=data["reserved_soc"],
@@ -96,7 +97,7 @@ class EnvoyStorageSettings:
     def to_api(self) -> dict[str, Any]:
         """Convert to API format."""
         retval = {
-            "mode": self.mode.value,
+            "mode": self.mode.value if self.mode else None,
             "operation_mode_sub_type": self.operation_mode_sub_type,
             "reserved_soc": self.reserved_soc,
             "very_low_soc": self.very_low_soc,

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1383,6 +1383,14 @@ async def test_with_7_x_firmware(
         with pytest.raises(TypeError):
             await envoy.set_storage_mode("invalid")
 
+        # test correct handling if storage_settings mode = None
+        # should result no longer throw Valueerror but result in None value
+        json_data = load_json_fixture(version, "admin_lib_tariff")
+        json_data["tariff"]["storage_settings"]["mode"] = None
+        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+        await envoy.update()
+        assert envoy.data.tariff.storage_settings.mode is None
+
         # COV test with missing logger
         json_data = load_json_fixture(version, "admin_lib_tariff")
         del json_data["tariff"]["logger"]


### PR DESCRIPTION
Some Envoy return null in Tariff - storage_settings - mode. This causes an _"None is not a valid EnvoyStorageMode"_ exception. The issue is reported as an [HA issue](https://github.com/home-assistant/core/issues/135570#top) . Example debug log is provided with the tariff reply included.

This PR changes the  EnvoyStorageSettings.from_Api method to set mode to None if null is in the raw json.

```json
{
    "tariff": {
        "currency": {
            "code": "AUD"
        },
        "logger": "mylogger",
        "date": "1731383190",
        "storage_settings": {
            "mode": null,
            "operation_mode_sub_type": null,
            "reserved_soc": 0.0,
            "very_low_soc": 10,
            "charge_from_grid": false,
            "date": "1731383190"
        },
        "single_rate": {
            "rate": 0.2827,
            "sell": 0.07
        },
        "seasons": [],
        "seasons_sell": []
    },

```