### PR TITLE
test: deduplicate fixture loading by using single fixture load function

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -69,48 +69,148 @@ async def get_mock_envoy(update: bool = True):  # type: ignore[no-untyped-def]
 
 
 def prep_envoy(
-    version: str,
-    info: bool = False,  #: if true mock info
-    meters: bool = True,  #: if true mock meters
-    inverters: bool = True,  #: if true mock inverters
-) -> None:
-    """Setup response mocks for envoy requests."""
+    version: str,  #: name of version folder to read fixtures from
+) -> list[str]:
+    """Setup response mocks for envoy requests and return list of found mock files."""
     path = f"{_fixtures_dir()}/{version}"
     files = [f for f in listdir(path) if isfile(join(path, f))]
 
-    if info:
-        respx.get("/info").mock(
-            return_value=Response(200, text=load_fixture(version, "info"))
+    respx.get("/info").mock(
+        return_value=Response(200, text=load_fixture(version, "info"))
+    )
+    respx.get("/info.xml").mock(return_value=Response(200, text=""))
+
+    if "ivp_meters" in files:
+        try:
+            respx.get("/ivp/meters").mock(
+                return_value=Response(
+                    200, json=load_json_fixture(version, "ivp_meters")
+                )
+            )
+        except json.decoder.JSONDecodeError:
+            # v3 fw with html return 401
+            respx.get("ivp_meters").mock(return_value=Response(401))
+    else:
+        respx.get("/ivp/meters").mock(return_value=Response(404))
+
+    if "ivp_meters_readings" in files:
+        respx.get("/ivp/meters/readings").mock(
+            return_value=Response(
+                200, json=load_json_fixture(version, "ivp_meters_readings")
+            )
         )
+    else:
+        respx.get("/ivp/meters/readings").mock(return_value=Response(404))
 
-    if meters:
-        respx.get("/ivp/meters").mock(return_value=Response(200, text="[]"))
+    if "production" in files:
+        try:
+            json_data = load_json_fixture(version, "production")
+            respx.get("/production").mock(return_value=Response(200, json=json_data))
+        except json.decoder.JSONDecodeError:
+            # v3 fw reports production in html format
+            respx.get("/production").mock(
+                return_value=Response(200, text=load_fixture(version, "production"))
+            )
+    else:
+        respx.get("/production").mock(return_value=Response(404))
 
-    respx.get("/production").mock(
-        return_value=Response(200, text=load_fixture(version, "production"))
-    )
-    respx.get("/production.json").mock(
-        return_value=Response(200, text=load_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    if inverters:
+    if "production.json" in files:
+        try:
+            respx.get("/production.json").mock(
+                return_value=Response(
+                    200, json=load_json_fixture(version, "production.json")
+                )
+            )
+            respx.get("/production.json?details=1").mock(
+                return_value=Response(
+                    200, json=load_json_fixture(version, "production.json")
+                )
+            )
+        except json.decoder.JSONDecodeError:
+            respx.get("/production.json").mock(return_value=Response(404))
+            respx.get("/production.json?details=1").mock(return_value=Response(404))
+    else:
+        respx.get("/production.json").mock(return_value=Response(404))
+        respx.get("/production.json?details=1").mock(return_value=Response(404))
+
+    if "api_v1_production" in files:
+        respx.get("/api/v1/production").mock(
+            return_value=Response(
+                200, json=load_json_fixture(version, "api_v1_production")
+            )
+        )
+    else:
+        respx.get("/api/v1/production").mock(return_value=Response(404))
+
+    if "api_v1_production_inverters" in files:
         respx.get("/api/v1/production/inverters").mock(
             return_value=Response(
                 200, json=load_json_fixture(version, "api_v1_production_inverters")
             )
         )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
+    else:
+        respx.get("/api/v1/production/inverters").mock(return_value=Response(404))
+
+    if "ivp_ensemble_inventory" in files:
+        respx.get("/ivp/ensemble/inventory").mock(
+            return_value=Response(
+                200, json=load_json_fixture(version, "ivp_ensemble_inventory")
+            )
+        )
+    else:
+        respx.get("/ivp/ensemble/inventory").mock(return_value=Response(404))
+
+    if "ivp_ensemble_dry_contacts" in files:
+        try:
+            json_data = load_json_fixture(version, "ivp_ensemble_dry_contacts")
+        except json.decoder.JSONDecodeError:
+            json_data = {}
+        respx.get("/ivp/ensemble/dry_contacts").mock(
+            return_value=Response(200, json=json_data)
+        )
+        respx.post("/ivp/ensemble/dry_contacts").mock(
+            return_value=Response(200, json=json_data)
+        )
+
+    if "ivp_ss_dry_contact_settings" in files:
+        try:
+            json_data = load_json_fixture(version, "ivp_ss_dry_contact_settings")
+        except json.decoder.JSONDecodeError:
+            json_data = {}
+        respx.get("/ivp/ss/dry_contact_settings").mock(
+            return_value=Response(200, json=json_data)
+        )
+        respx.post("/ivp/ss/dry_contact_settings").mock(
+            return_value=Response(200, json=json_data)
+        )
+
+    if "ivp_ensemble_power" in files:
+        try:
+            json_data = load_json_fixture(version, "ivp_ensemble_power")
+        except json.decoder.JSONDecodeError:
+            json_data = {}
+        respx.get("/ivp/ensemble/power").mock(
+            return_value=Response(200, json=json_data)
+        )
+
+    if "ivp_ensemble_secctrl" in files:
+        try:
+            json_data = load_json_fixture(version, "ivp_ensemble_secctrl")
+        except json.decoder.JSONDecodeError:
+            json_data = {}
+        respx.get("/ivp/ensemble/secctrl").mock(
+            return_value=Response(200, json=json_data)
+        )
 
     if "admin_lib_tariff" in files:
         try:
             json_data = load_json_fixture(version, "admin_lib_tariff")
         except json.decoder.JSONDecodeError:
-            json_data = None
+            json_data = {}
         respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
+        respx.put("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
     else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(401))
+        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
 
     if "ivp_ss_gen_config" in files:
         try:
@@ -120,6 +220,8 @@ def prep_envoy(
         respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
     else:
         respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
+
+    return files
 
 
 def updater_features(updaters: list[EnvoyUpdater]) -> dict[str, SupportedFeatures]:

--- a/tests/test_acb.py
+++ b/tests/test_acb.py
@@ -1,9 +1,6 @@
 """Test ACB battery data and combined Encharge/ACB"""
 
-import json
 import logging
-from os import listdir
-from os.path import isfile, join
 from typing import Any
 
 import pytest
@@ -16,8 +13,8 @@ from pyenphase.models.envoy import EnvoyData
 
 from .common import (
     get_mock_envoy,
-    load_fixture,
     load_json_fixture,
+    prep_envoy,
     start_7_firmware_mock,
 )
 
@@ -30,40 +27,7 @@ async def test_with_4_2_27_firmware():
     """Verify with 4.2.27 firmware."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "4.2.27"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(
-        return_value=Response(200, json=load_json_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(return_value=Response(404))
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    if "ivp_ss_gen_config" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ss_gen_config")
-        except json.decoder.JSONDecodeError:
-            json_data = {}
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-
-    respx.get("/ivp/meters").mock(return_value=Response(200, json=[]))
+    prep_envoy(version)
 
     envoy = await get_mock_envoy()
     data: EnvoyData | None = envoy.data
@@ -327,127 +291,7 @@ async def test_with_7_x_firmware(
     """
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     start_7_firmware_mock()
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-
-    if "production" in files:
-        try:
-            json_data = load_json_fixture(version, "production")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/production").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/production").mock(return_value=Response(404))
-
-    if "production.json" in files:
-        respx.get("/production.json").mock(
-            return_value=Response(
-                200, json=load_json_fixture(version, "production.json")
-            )
-        )
-        respx.get("/production.json?details=1").mock(
-            return_value=Response(
-                200, json=load_json_fixture(version, "production.json")
-            )
-        )
-    else:
-        respx.get("/production.json").mock(return_value=Response(404))
-        respx.get("/production.json?details=1").mock(return_value=Response(404))
-
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "ivp_ensemble_inventory")
-        )
-    )
-
-    if "ivp_ensemble_dry_contacts" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ensemble_dry_contacts")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/ivp/ensemble/dry_contacts").mock(
-            return_value=Response(200, json=json_data)
-        )
-        respx.post("/ivp/ensemble/dry_contacts").mock(
-            return_value=Response(200, json=json_data)
-        )
-
-    if "ivp_ss_dry_contact_settings" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ss_dry_contact_settings")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/ivp/ss/dry_contact_settings").mock(
-            return_value=Response(200, json=json_data)
-        )
-        respx.post("/ivp/ss/dry_contact_settings").mock(
-            return_value=Response(200, json=json_data)
-        )
-
-    if "ivp_ensemble_power" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ensemble_power")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/ivp/ensemble/power").mock(
-            return_value=Response(200, json=json_data)
-        )
-
-    if "ivp_ensemble_secctrl" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ensemble_secctrl")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/ivp/ensemble/secctrl").mock(
-            return_value=Response(200, json=json_data)
-        )
-
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-        respx.put("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    if "ivp_meters" in files:
-        respx.get("/ivp/meters").mock(
-            return_value=Response(200, json=load_json_fixture(version, "ivp_meters"))
-        )
-    else:
-        respx.get("/ivp/meters").mock(return_value=Response(404))
-
-    if "ivp_meters_readings" in files:
-        respx.get("/ivp/meters/readings").mock(
-            return_value=Response(
-                200, json=load_json_fixture(version, "ivp_meters_readings")
-            )
-        )
-    else:
-        respx.get("/ivp/meters/readings").mock(return_value=Response(404))
-
-    if "ivp_ss_gen_config" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ss_gen_config")
-        except json.decoder.JSONDecodeError:
-            json_data = {}
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
+    prep_envoy(version)
 
     caplog.set_level(logging.DEBUG)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -34,7 +34,7 @@ async def test_wrong_auth_order_with_7_6_175_standard():
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
     envoy = Envoy("127.0.0.1")
     await envoy.setup()
 
@@ -141,7 +141,7 @@ async def test_known_users_with_3_9_36_firmware(username: str, password: str) ->
     """Test successful login with known usernames."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.9.36"
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     envoy = Envoy("127.0.0.1")
     await envoy.setup()
@@ -167,7 +167,7 @@ async def test_unknown_user_with_3_9_36_firmware():
     """Test Could not setup authentication object with 3.9.x"""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.9.36"
-    prep_envoy(version, info=True, inverters=False)
+    prep_envoy(version)
 
     envoy = Envoy("127.0.0.1")
     await envoy.setup()
@@ -195,7 +195,7 @@ async def test_blank_passwords_with_7_6_175_standard(
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     envoy = Envoy("127.0.0.1")
 
@@ -212,7 +212,7 @@ async def test_no_token_obtained_with_7_6_175_standard() -> None:
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     with patch("pyenphase.EnvoyTokenAuth._obtain_token", return_value=None):
         envoy = Envoy("127.0.0.1")
@@ -228,7 +228,7 @@ async def test_jwt_failure_with_7_6_175_standard() -> None:
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     respx.get(URL_AUTH_CHECK_JWT).mock(return_value=Response(404, text="no jwt"))
 
@@ -245,7 +245,7 @@ async def test_no_remote_login_with_7_6_175_standard() -> None:
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     respx.post("https://enlighten.enphaseenergy.com/login/login.json?").mock(
         return_value=Response(
@@ -278,7 +278,7 @@ async def test_no_remote_token_with_7_6_175_standard() -> None:
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     respx.post("https://enlighten.enphaseenergy.com/login/login.json?").mock(
         return_value=Response(
@@ -315,7 +315,7 @@ async def test_enlighten_json_error_with_7_6_175_standard() -> None:
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     respx.post("https://enlighten.enphaseenergy.com/login/login.json?").mock(
         return_value=Response(
@@ -341,7 +341,7 @@ async def test_token_with_7_6_175_standard() -> None:
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     envoy = Envoy("127.0.0.1")
     await envoy.setup()
@@ -388,7 +388,7 @@ async def test_remote_login_response_with_7_6_175_standard() -> None:
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     envoy = Envoy("127.0.0.1")
     await envoy.setup()

--- a/tests/test_ct_meters.py
+++ b/tests/test_ct_meters.py
@@ -18,6 +18,7 @@ from .common import (
     load_fixture,
     load_json_fixture,
     load_json_list_fixture,
+    prep_envoy,
     start_7_firmware_mock,
     updater_features,
 )
@@ -32,30 +33,7 @@ async def test_pr111_with_7_3_466_metered_disabled_cts():
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.3.466_metered_disabled_cts"
     start_7_firmware_mock()
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(
-        return_value=Response(200, text=load_fixture(version, "production"))
-    )
-    respx.get("/production.json").mock(
-        return_value=Response(200, text=load_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-    respx.get("/ivp/meters").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters"))
-    )
+    prep_envoy(version)
 
     envoy = await get_mock_envoy()
     data = envoy.data
@@ -69,6 +47,7 @@ async def test_pr111_with_7_3_466_metered_disabled_cts():
     assert updater_features(envoy._updaters) == {
         "EnvoyProductionJsonFallbackUpdater": SupportedFeatures.PRODUCTION,
         "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
+        "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
     }
     assert envoy.part_number == "800-00654-r08"
 
@@ -86,33 +65,8 @@ async def test_pr111_with_7_6_175_with_cts():
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_with_cts"
     start_7_firmware_mock()
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(
-        return_value=Response(200, text=load_fixture(version, "production"))
-    )
-    respx.get("/production.json").mock(
-        return_value=Response(200, text=load_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-    respx.get("/ivp/meters").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters"))
-    )
-    respx.get("/ivp/meters/readings").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters_readings"))
-    )
+    prep_envoy(version)
+
     envoy = await get_mock_envoy()
     data = envoy.data
     assert data is not None
@@ -131,6 +85,7 @@ async def test_pr111_with_7_6_175_with_cts():
         | SupportedFeatures.NET_CONSUMPTION
         | SupportedFeatures.PRODUCTION,
         "EnvoyMetersUpdater": SupportedFeatures.CTMETERS,
+        "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
     }
 
     assert envoy.part_number == "800-00654-r08"
@@ -153,28 +108,7 @@ async def test_pr111_with_7_6_175_standard():
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(
-        return_value=Response(200, text=load_fixture(version, "production"))
-    )
-    respx.get("/production.json").mock(
-        return_value=Response(200, text=load_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-    respx.get("/ivp/meters").mock(return_value=Response(200, text=""))
+    prep_envoy(version)
 
     envoy = await get_mock_envoy()
     data = envoy.data
@@ -208,33 +142,7 @@ async def test_ct_data_structures_with_7_3_466_with_cts_3phase():
     # start with regular data first
     version = "7.3.466_with_cts_3phase"
     start_7_firmware_mock()
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(
-        return_value=Response(200, text=load_fixture(version, "production"))
-    )
-    respx.get("/production.json").mock(
-        return_value=Response(200, text=load_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-    respx.get("/ivp/meters").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters"))
-    )
-    respx.get("/ivp/meters/readings").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters_readings"))
-    )
+    prep_envoy(version)
 
     # details of this test is done elsewhere already, just check data is returned
     envoy = await get_mock_envoy()
@@ -342,33 +250,7 @@ async def test_ct_data_structures_with_7_6_175_with_cts_3phase():
     # start with regular data first
     version = "7.6.175_with_cts_3phase"
     start_7_firmware_mock()
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(
-        return_value=Response(200, text=load_fixture(version, "production"))
-    )
-    respx.get("/production.json").mock(
-        return_value=Response(200, text=load_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    respx.get("/ivp/meters").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters"))
-    )
-    respx.get("/ivp/meters/readings").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters_readings"))
-    )
+    prep_envoy(version)
 
     # details of this test is done elsewhere already, just check data is returned
     envoy = await get_mock_envoy()
@@ -435,48 +317,26 @@ async def test_ct_data_structures_with_7_6_175_with_cts_3phase():
 @pytest.mark.asyncio
 @respx.mock
 async def test_ct_data_structures_with_7_6_175_with_total_cts_3phase():
-    """Test meters model using envoy metered total-consumption CT with multiple phases"""
+    """Test meters model using envoy metered without production CT and total-consumption CT with multiple phases"""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
 
     # start with regular data first
     version = "7.6.175_with_cts_3phase"
     start_7_firmware_mock()
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-
-    # remove production segment from production for COV test
-    production_json = load_json_fixture(version, "production")
-    del production_json["production"]
-    respx.get("/production").mock(return_value=Response(200, json=production_json))
+    prep_envoy(version)
     production_json = load_json_fixture(version, "production.json")
+    # remove production data to test COV consumption ct only
     del production_json["production"]
     respx.get("/production.json").mock(return_value=Response(200, json=production_json))
-    production_json = load_json_fixture(version, "production.json")
-    del production_json["production"]
     respx.get("/production.json?details=1").mock(
         return_value=Response(200, json=production_json)
     )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
 
     # Force ct consumption meter to total consumption for COV
     ivp_Meters = load_fixture(version, "ivp_meters").replace(
         CtType.NET_CONSUMPTION, CtType.TOTAL_CONSUMPTION
     )
     respx.get("/ivp/meters").mock(return_value=Response(200, text=ivp_Meters))
-    respx.get("/ivp/meters/readings").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters_readings"))
-    )
 
     # details of this test is done elsewhere already, just check data is returned
     envoy = await get_mock_envoy()
@@ -498,33 +358,7 @@ async def test_ct_storage_with_8_2_127_with_3cts_and_battery_split():
     # start with regular data first
     version = "8.2.127_with_3cts_and_battery_split"
     start_7_firmware_mock()
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(
-        return_value=Response(200, text=load_fixture(version, "production"))
-    )
-    respx.get("/production.json").mock(
-        return_value=Response(200, text=load_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-    respx.get("/ivp/meters").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters"))
-    )
-    respx.get("/ivp/meters/readings").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters_readings"))
-    )
+    prep_envoy(version)
 
     # details of this test is done elsewhere already, just check data is returned
     envoy = await get_mock_envoy()
@@ -594,30 +428,8 @@ async def test_ct_storage_data_without_meter_entry_with_8_2_127_with_3cts_and_ba
     # start with regular data first we use this fixture to test issue reported in 8.3.5025
     version = "8.2.127_with_3cts_and_battery_split"
     start_7_firmware_mock()
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(
-        return_value=Response(200, text=load_fixture(version, "production"))
-    )
-    respx.get("/production.json").mock(
-        return_value=Response(200, text=load_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-    respx.get("/ivp/meters").mock(
-        return_value=Response(200, text=load_fixture(version, "ivp_meters"))
-    )
+    prep_envoy(version)
+
     # fw D8.3.5027 has 3th (zero) entry for Storage CT, even if not configured
     # this caused Indexerror crash. Test if extra data is now handled without crash
     readings_data = load_json_list_fixture(version, "ivp_meters_readings")

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -118,7 +118,7 @@ async def test_firmware_no_fw_with_7_6_175_standard():
     envoy = Envoy("127.0.0.1")
     await envoy.setup()
 
-    assert envoy.firmware is None
+    assert not envoy.firmware
     assert envoy.serial_number == "123456789012"
     assert envoy.part_number == "800-12345-r99"
 
@@ -137,7 +137,7 @@ async def test_firmware_no_device_with_7_6_175_standard():
     envoy = Envoy("127.0.0.1")
     await envoy.setup()
 
-    assert envoy.firmware is None
+    assert not envoy.firmware
     assert envoy.serial_number is None
     assert envoy.part_number is None
 

--- a/tests/test_net_consumption.py
+++ b/tests/test_net_consumption.py
@@ -1,14 +1,10 @@
 """Test endpoint for envoy v7 and newer firmware"""
 
-import json
 import logging
-from os import listdir
-from os.path import isfile, join
 from typing import Any
 
 import pytest
 import respx
-from httpx import Response
 from syrupy.assertion import SnapshotAssertion
 
 from pyenphase.const import PhaseNames
@@ -17,8 +13,7 @@ from pyenphase.models.envoy import EnvoyData
 
 from .common import (
     get_mock_envoy,
-    load_fixture,
-    load_json_fixture,
+    prep_envoy,
     start_7_firmware_mock,
 )
 
@@ -31,40 +26,7 @@ async def test_with_4_2_27_firmware():
     """Verify with 4.2.27 firmware."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "4.2.27"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(
-        return_value=Response(200, json=load_json_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(return_value=Response(404))
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    if "ivp_ss_gen_config" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ss_gen_config")
-        except json.decoder.JSONDecodeError:
-            json_data = {}
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-
-    respx.get("/ivp/meters").mock(return_value=Response(200, json=[]))
+    prep_envoy(version)
 
     envoy = await get_mock_envoy()
     data: EnvoyData | None = envoy.data
@@ -430,121 +392,7 @@ async def test_with_7_x_firmware(
     """Verify with 7.x firmware."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     start_7_firmware_mock()
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    if "production" in files:
-        try:
-            json_data = load_json_fixture(version, "production")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/production").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/production").mock(return_value=Response(404))
-    if "production.json" in files:
-        respx.get("/production.json").mock(
-            return_value=Response(
-                200, json=load_json_fixture(version, "production.json")
-            )
-        )
-        respx.get("/production.json?details=1").mock(
-            return_value=Response(
-                200, json=load_json_fixture(version, "production.json")
-            )
-        )
-    else:
-        respx.get("/production.json").mock(return_value=Response(404))
-        respx.get("/production.json?details=1").mock(return_value=Response(404))
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "ivp_ensemble_inventory")
-        )
-    )
-    if "ivp_ensemble_dry_contacts" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ensemble_dry_contacts")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/ivp/ensemble/dry_contacts").mock(
-            return_value=Response(200, json=json_data)
-        )
-        respx.post("/ivp/ensemble/dry_contacts").mock(
-            return_value=Response(200, json=json_data)
-        )
-    if "ivp_ss_dry_contact_settings" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ss_dry_contact_settings")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/ivp/ss/dry_contact_settings").mock(
-            return_value=Response(200, json=json_data)
-        )
-        respx.post("/ivp/ss/dry_contact_settings").mock(
-            return_value=Response(200, json=json_data)
-        )
-    if "ivp_ensemble_power" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ensemble_power")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/ivp/ensemble/power").mock(
-            return_value=Response(200, json=json_data)
-        )
-
-    if "ivp_ensemble_secctrl" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ensemble_secctrl")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/ivp/ensemble/secctrl").mock(
-            return_value=Response(200, json=json_data)
-        )
-
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-        respx.put("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    if "ivp_meters" in files:
-        respx.get("/ivp/meters").mock(
-            return_value=Response(200, json=load_json_fixture(version, "ivp_meters"))
-        )
-    else:
-        respx.get("/ivp/meters").mock(return_value=Response(404))
-
-    if "ivp_meters_readings" in files:
-        respx.get("/ivp/meters/readings").mock(
-            return_value=Response(
-                200, json=load_json_fixture(version, "ivp_meters_readings")
-            )
-        )
-    else:
-        respx.get("/ivp/meters/readings").mock(return_value=Response(404))
-
-    if "ivp_ss_gen_config" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ss_gen_config")
-        except json.decoder.JSONDecodeError:
-            json_data = {}
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
+    prep_envoy(version)
 
     caplog.set_level(logging.DEBUG)
 

--- a/tests/test_pre_v7_endpoints.py
+++ b/tests/test_pre_v7_endpoints.py
@@ -1,10 +1,7 @@
 """Test envoy firmware prior to v7."""
 
-import json
 import logging
 import re
-from os import listdir
-from os.path import isfile, join
 
 import pytest
 import respx
@@ -25,7 +22,12 @@ from pyenphase.models.meters import EnvoyPhaseMode
 from pyenphase.models.system_production import EnvoySystemProduction
 from pyenphase.updaters.base import EnvoyUpdater
 
-from .common import get_mock_envoy, load_fixture, load_json_fixture, updater_features
+from .common import (
+    get_mock_envoy,
+    load_json_fixture,
+    prep_envoy,
+    updater_features,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,40 +38,7 @@ async def test_with_4_2_27_firmware():
     """Verify with 4.2.27 firmware."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "4.2.27"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(
-        return_value=Response(200, json=load_json_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(return_value=Response(404))
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    if "ivp_ss_gen_config" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ss_gen_config")
-        except json.decoder.JSONDecodeError:
-            json_data = {}
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-
-    respx.get("/ivp/meters").mock(return_value=Response(200, json=[]))
+    prep_envoy(version)
 
     envoy = await get_mock_envoy()
     data: EnvoyData | None = envoy.data
@@ -113,51 +82,7 @@ async def test_with_4_2_33_firmware_no_cons_ct():
     """Verify with 4.2.33 firmware."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "4.2.33"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(
-        return_value=Response(200, json=load_json_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    if "ivp_ss_gen_config" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ss_gen_config")
-        except json.decoder.JSONDecodeError:
-            json_data = {}
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-
-    respx.get("/ivp/meters").mock(
-        return_value=Response(200, json=load_json_fixture(version, "ivp_meters"))
-    )
-    respx.get("/ivp/meters/readings").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "ivp_meters_readings")
-        )
-    )
+    prep_envoy(version)
 
     envoy = await get_mock_envoy()
     data: EnvoyData | None = envoy.data
@@ -218,45 +143,7 @@ async def test_with_5_0_49_firmware():
     """Verify with 5.0.49 firmware."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "5.0.49"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(
-        return_value=Response(200, json=load_json_fixture(version, "production.json"))
-    )
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    if "ivp_ss_gen_config" in files:
-        try:
-            json_data = load_json_fixture(version, "ivp_ss_gen_config")
-        except json.decoder.JSONDecodeError:
-            json_data = {}
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
-
-    respx.get("/ivp/meters").mock(return_value=Response(404))
+    prep_envoy(version)
 
     envoy = await get_mock_envoy()
     data = envoy.data
@@ -534,27 +421,7 @@ async def test_with_3_7_0_firmware():
     """Verify with 3.7.0 firmware."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.7.0"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(
-        return_value=Response(200, text=load_fixture(version, "production"))
-    )
-    respx.get("/production.json").mock(return_value=Response(404))
-    respx.get("/api/v1/production").mock(
-        return_value=Response(
-            404,
-        )
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            404,
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-    respx.get("/ivp/meters").mock(return_value=Response(404))
+    prep_envoy(version)
 
     # Verify the library does not support scraping to comply with ADR004
     with pytest.raises(EnvoyProbeFailed):
@@ -662,34 +529,11 @@ async def test_with_3_9_36_firmware_bad_auth():
     """Verify with 3.9.36 firmware with incorrect auth."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.9.36_bad_auth"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(return_value=Response(404))
+    prep_envoy(version)
+    # for auth failure
     respx.get("/api/v1/production").mock(
         return_value=Response(401, json=load_json_fixture(version, "api_v1_production"))
     )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(401))
-
-    respx.get("/ivp/meters").mock(return_value=Response(200, json=[]))
 
     with pytest.raises(EnvoyAuthenticationRequired):
         await get_mock_envoy()
@@ -701,34 +545,13 @@ async def test_with_3_9_36_firmware_no_inverters():
     """Verify with 3.9.36 firmware with auth that does not allow inverters."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.9.36_bad_auth"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(return_value=Response(404))
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
+    prep_envoy(version)
+    # force auth failure on inverters
     respx.get("/api/v1/production/inverters").mock(
         return_value=Response(
             401, json=load_json_fixture(version, "api_v1_production_inverters")
         )
     )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(401))
-
-    respx.get("/ivp/meters").mock(return_value=Response(404))
 
     envoy = await get_mock_envoy()
     data = envoy.data
@@ -755,36 +578,9 @@ async def test_with_3_9_36_firmware():
     """Verify with 3.9.36 firmware."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.9.36"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(return_value=Response(404))
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(401))
-
-    respx.get("/ivp/meters").mock(
-        return_value=Response(404, json={"error": "404 - Not Found"})
-    )
+    prep_envoy(version)
+    # no access to tariff
+    respx.get("/admin/lib/tariff").mock(return_value=Response(401))
 
     envoy = await get_mock_envoy()
     data = envoy.data
@@ -893,34 +689,9 @@ async def test_with_3_9_36_firmware_with_production_401():
     """Verify with 3.9.36 firmware when /production throws a 401."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.9.36"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
+    prep_envoy(version)
+    # force 401 on production
     respx.get("/production").mock(return_value=Response(401))
-    respx.get("/production.json").mock(return_value=Response(404))
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    respx.get("/ivp/meters").mock(return_value=Response(404))
 
     envoy = await get_mock_envoy()
     data = envoy.data
@@ -955,32 +726,10 @@ async def test_with_3_9_36_firmware_with_production_and_production_json_401():
     """Verify with 3.9.36 firmware when /production and /production.json throws a 401."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.9.36"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
+    prep_envoy(version)
+    # force 401 on production
     respx.get("/production").mock(return_value=Response(401))
     respx.get("/production.json").mock(return_value=Response(401))
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-    respx.get("/ivp/meters").mock(return_value=Response(200, json=[]))
 
     with pytest.raises(EnvoyAuthenticationRequired):
         await get_mock_envoy()
@@ -988,76 +737,17 @@ async def test_with_3_9_36_firmware_with_production_and_production_json_401():
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_with_3_9_36_firmware_with_meters_401():
-    """Verify with 3.9.36 firmware when /ivp/meters throws a 401."""
-    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
-    version = "3.9.36"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(return_value=Response(401))
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-    respx.get("/ivp/meters").mock(return_value=Response(401))
-
-    with pytest.raises(EnvoyAuthenticationRequired):
-        await get_mock_envoy()
-
-
-@pytest.mark.asyncio
-@respx.mock
-async def test_with_3_8_10_firmware_with_meters_401():
+async def test_with_3_8_10_firmware_with_meters_401(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Verify with 3.8.10 firmware when /ivp/meters throws a 401."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.8.10"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(return_value=Response(401))
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
+    prep_envoy(version)
     respx.get("/ivp/meters").mock(return_value=Response(401))
-
-    with pytest.raises(EnvoyAuthenticationRequired):
-        await get_mock_envoy()
+    caplog.set_level(logging.DEBUG)
+    await get_mock_envoy()
+    assert "Skipping meters endpoint as user does not have access to" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1066,34 +756,7 @@ async def test_with_3_17_3_firmware():
     """Verify with 3.17.3 firmware."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.17.3"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(return_value=Response(404))
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    respx.get("/ivp/meters").mock(return_value=Response(200, json=[]))
+    prep_envoy(version)
 
     envoy = await get_mock_envoy()
     data = envoy.data
@@ -1375,34 +1038,7 @@ async def test_with_3_17_3_firmware_zero_production():
     """Verify with 3.17.3 firmware."""
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "3.17.3"
-    respx.get("/info").mock(
-        return_value=Response(200, text=load_fixture(version, "info"))
-    )
-    respx.get("/info.xml").mock(return_value=Response(200, text=""))
-    respx.get("/production").mock(return_value=Response(404))
-    respx.get("/production.json").mock(return_value=Response(404))
-    respx.get("/api/v1/production").mock(
-        return_value=Response(200, json=load_json_fixture(version, "api_v1_production"))
-    )
-    respx.get("/api/v1/production/inverters").mock(
-        return_value=Response(
-            200, json=load_json_fixture(version, "api_v1_production_inverters")
-        )
-    )
-    respx.get("/ivp/ensemble/inventory").mock(return_value=Response(200, json=[]))
-
-    path = f"tests/fixtures/{version}"
-    files = [f for f in listdir(path) if isfile(join(path, f))]
-    if "admin_lib_tariff" in files:
-        try:
-            json_data = load_json_fixture(version, "admin_lib_tariff")
-        except json.decoder.JSONDecodeError:
-            json_data = None
-        respx.get("/admin/lib/tariff").mock(return_value=Response(200, json=json_data))
-    else:
-        respx.get("/admin/lib/tariff").mock(return_value=Response(404))
-
-    respx.get("/ivp/meters").mock(return_value=Response(200, json=[]))
+    prep_envoy(version)
 
     envoy = await get_mock_envoy()
 

--- a/tests/test_retries.py
+++ b/tests/test_retries.py
@@ -32,7 +32,7 @@ async def test_full_connected_from_start_with_7_6_175_standard():
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version=version, info=True)
+    prep_envoy(version)
 
     envoy = Envoy("127.0.0.1")
     # remove the waits between retries for this test and set known retries
@@ -110,7 +110,7 @@ async def test_httperror_from_start_with_7_6_175_standard():
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version=version)
+    prep_envoy(version)
 
     envoy = Envoy("127.0.0.1")
     envoy._firmware._get_info.retry.wait = wait_none()
@@ -138,7 +138,7 @@ async def test_1_timeout_from_start_with_7_6_175_standard():
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version=version)
+    prep_envoy(version)
 
     envoy = Envoy("127.0.0.1")
     envoy._firmware._get_info.retry.wait = wait_none()
@@ -276,7 +276,7 @@ async def test_noconnection_at_probe_with_7_6_175_standard():
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     envoy = Envoy("127.0.0.1")
     # remove the waits between retries for this test and set known retries
@@ -321,7 +321,7 @@ async def test_noconnection_at_update_with_7_6_175_standard():
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
 
     envoy = Envoy("127.0.0.1")
     # remove the waits between retries for this test and set known retries
@@ -439,7 +439,7 @@ async def test_bad_request_status_7_6_175_standard():
     logging.getLogger("pyenphase").setLevel(logging.DEBUG)
     version = "7.6.175_standard"
     start_7_firmware_mock()
-    prep_envoy(version, info=True)
+    prep_envoy(version)
     envoy = Envoy("127.0.0.1")
     envoy._firmware._get_info.retry.wait = wait_none()
     envoy._firmware._get_info.retry.stop = stop_after_attempt(3) | stop_after_delay(50)


### PR DESCRIPTION
Currently, many tests use their own fixture loading code. This requires code changes in multiple places if anything needs to change as well as large repeated code sections.

This PR extends the function prep_envoy in common.py to implement all fixture loading and replaces all fixture loading code by a call to prep_envoy. 

Modified tests result in no snapshot changes and same 100% code coverage as before.

