### PR TITLE
feat: add method to return envoy active interface settings

### DIFF
--- a/docs/model_autodoc.md
+++ b/docs/model_autodoc.md
@@ -290,6 +290,16 @@
   :member-order: bysource
 ```
 
+## Interface data
+
+```{eval-rst}
+.. autoclass:: pyenphase.models.home.EnvoyInterfaceInformation
+  :members:
+  :undoc-members:
+  :show-inheritance:
+  :member-order: bysource
+```
+
 # Utilities
 
 ## Json

--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -39,6 +39,9 @@ URL_GEN_SCHEDULE = "/ivp/ss/gen_schedule"
 ENDPOINT_URL_METERS = "/ivp/meters"
 ENDPOINT_URL_METERS_READINGS = "/ivp/meters/readings"
 
+# Interface configuration
+ENDPOINT_URL_HOME = "/home"
+
 LOCAL_TIMEOUT = httpx.Timeout(
     # The envoy can be slow to respond but fast to connect to we
     # need to set a long timeout for the read and a short timeout

--- a/src/pyenphase/models/home.py
+++ b/src/pyenphase/models/home.py
@@ -1,0 +1,108 @@
+"""Model for ENphase Envoy home data"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+def _find_active_interface(
+    interfaces: list[dict[str, Any]], name: str
+) -> dict[str, Any] | None:
+    """Find an interface by interface name."""
+    if interfaces:
+        for interface in interfaces:
+            if interface.get("interface") == name:
+                return interface
+    return None
+
+
+@dataclass(slots=True)
+class EnvoyInterfaceInformation:
+    """Envoy Interface information data model."""
+
+    primary_interface: str  #: name of primary (active) interface
+    mac: str  #: mac of primary interface, "unknown" if missing
+    interface_type: str  #: primary interface type, "unknown" if missing
+    dhcp: bool  #: interfaces uses DHCP, False if missing
+    software_build_epoch: int  #: envoy software build time, 0 if missing
+    timezone: str  #: Timezone set in Envoy, "unknown" if missing
+
+    @classmethod
+    def from_api(cls, data: dict[str, Any]) -> EnvoyInterfaceInformation | None:
+        """
+        Return active interface information configured in Envoy
+
+        Parses the received JSON into EnvoyInterfaceInformation model data
+        Source data must be sourced from URL_HOME.
+
+        software_build_epoch, timezone are returned as is.
+        network.primary_interface is returned as is, and used
+        to find interface data in network.interfaces from which
+        type, mac and dhcp are returned.
+
+        Not all Envoy firmware version may return all data. Defaults for
+        str members is unknown, int 0 and bool False
+
+        Example json returned from /home endpoint:
+
+            .. code-block:: json
+
+                {
+                "software_build_epoch": 1719503966,
+                "timezone": "Europe/Amsterdam",
+                "current_date": "04/24/2025",
+                "current_time": "14:53",
+                "network": {
+                    "web_comm": true,
+                    "ever_reported_to_enlighten": true,
+                    "last_enlighten_report_time": 1745499043,
+                    "primary_interface": "eth0",
+                    "interfaces": [
+                    {
+                        "type": "ethernet",
+                        "interface": "eth0",
+                        "mac": "00:1D:C0:7F:B6:3B",
+                        "dhcp": true,
+                        "ip": "192.168.3.112",
+                        "signal_strength": 1,
+                        "signal_strength_max": 1,
+                        "carrier": true
+                    },
+                    {
+                        "signal_strength": 0,
+                        "signal_strength_max": 0,
+                        "type": "wifi",
+                        "interface": "wlan0",
+                        "mac": "60:E8:5B:AB:9D:64",
+                        "dhcp": true,
+                        "ip": null,
+                        "carrier": false,
+                        "supported": true,
+                        "present": true,
+                        "configured": false,
+                        "status": "connecting"
+                    }
+                ]
+            }
+
+        :param data: json returned by /home endpoint
+        :return: Envoy interface configuration information
+        """
+        # not sure if all firmware versions have all the needed information
+        if not (network := data.get("network")):
+            return None
+        if not (
+            interface := _find_active_interface(
+                network.get("interfaces"), (name := network.get("primary_interface"))
+            )
+        ):
+            return None
+        return cls(
+            primary_interface=name,
+            mac=interface.get("mac", "unknown"),
+            interface_type=interface.get("type", "unknown"),
+            dhcp=interface.get("dhcp", False),
+            software_build_epoch=data.get("software_build_epoch", 0),
+            timezone=data.get("timezone", "unknown"),
+        )

--- a/tests/common.py
+++ b/tests/common.py
@@ -254,8 +254,7 @@ async def prep_envoy(
             return_value=Response(200, json=await load_json_fixture(version, "home"))
         )
     else:
-        respx.get("home").mock(return_value=Response(404))
-
+        respx.get("/home").mock(return_value=Response(404))
     return files
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -249,6 +249,13 @@ async def prep_envoy(
     else:
         respx.get("/ivp/ss/gen_config").mock(return_value=Response(200, json={}))
 
+    if "home" in files:
+        respx.get("/home").mock(
+            return_value=Response(200, json=await load_json_fixture(version, "home"))
+        )
+    else:
+        respx.get("home").mock(return_value=Response(404))
+
     return files
 
 

--- a/tests/fixtures/7.6.175/home
+++ b/tests/fixtures/7.6.175/home
@@ -1,0 +1,75 @@
+{
+  "software_build_epoch": 1719503966,
+  "timezone": "Europe/Amsterdam",
+  "current_date": "04/24/2025",
+  "current_time": "14:53",
+  "network": {
+    "web_comm": true,
+    "ever_reported_to_enlighten": true,
+    "last_enlighten_report_time": 1745499043,
+    "primary_interface": "eth0",
+    "interfaces": [
+      {
+        "type": "ethernet",
+        "interface": "eth0",
+        "mac": "00:1D:C0:7F:B6:3B",
+        "dhcp": true,
+        "ip": "192.168.3.112",
+        "signal_strength": 1,
+        "signal_strength_max": 1,
+        "carrier": true
+      },
+      {
+        "signal_strength": 0,
+        "signal_strength_max": 0,
+        "type": "wifi",
+        "interface": "wlan0",
+        "mac": "60:E8:5B:AB:9D:64",
+        "dhcp": true,
+        "ip": null,
+        "carrier": false,
+        "supported": true,
+        "present": true,
+        "configured": false,
+        "status": "connecting"
+      }
+    ]
+  },
+  "tariff": "single_rate",
+  "comm": {
+    "num": 24,
+    "level": 5,
+    "pcu": {
+      "num": 24,
+      "level": 5
+    },
+    "acb": {
+      "num": 0,
+      "level": 0
+    },
+    "nsrb": {
+      "num": 1,
+      "level": 5
+    },
+    "esub": {
+      "num": 0,
+      "level": 0
+    },
+    "encharge": [
+      {
+        "num": 0,
+        "level": 0,
+        "level_24g": 0,
+        "level_subg": 0
+      }
+    ]
+  },
+  "wireless_connection": [
+    {
+      "signal_strength": 0,
+      "signal_strength_max": 0,
+      "type": "BLE",
+      "connected": true
+    }
+  ]
+}

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -1,0 +1,188 @@
+"""Test envoy home endpoint"""
+
+import logging
+
+import httpx
+import pytest
+import respx
+from httpx import Response
+
+from pyenphase.models.home import EnvoyInterfaceInformation
+
+from .common import (
+    get_mock_envoy,
+    load_json_fixture,
+    prep_envoy,
+    start_7_firmware_mock,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_home_from_api_with_7_6_175():
+    """Test home data from api"""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+
+    # start with regular data first
+    version = "7.6.175"
+    start_7_firmware_mock()
+    await prep_envoy(version)
+
+    # details of this test is done elsewhere already, just check data is returned
+    envoy = await get_mock_envoy()
+    data = envoy.data
+    assert data is not None
+
+    # load mock data for home endpoint
+    home_json = await load_json_fixture(version, "home")
+
+    # test from_api method with eth0 interface
+    home_data: EnvoyInterfaceInformation | None = EnvoyInterfaceInformation.from_api(
+        home_json
+    )
+
+    # verify common data
+    assert home_data
+    assert home_data.software_build_epoch == 1719503966
+    assert home_data.dhcp
+    assert home_data.timezone == "Europe/Amsterdam"
+
+    # verify interface data
+    assert home_data.mac == "00:1D:C0:7F:B6:3B"
+    assert home_data.primary_interface == "eth0"
+    assert home_data.interface_type == "ethernet"
+
+    # force wifi interface
+    home_json["network"]["primary_interface"] = "wlan0"
+    home_data = EnvoyInterfaceInformation.from_api(home_json)
+
+    # verify interface data
+    assert home_data
+    assert home_data.mac == "60:E8:5B:AB:9D:64"
+    assert home_data.primary_interface == "wlan0"
+    assert home_data.interface_type == "wifi"
+
+    # test missing interface key
+    home_json["network"]["primary_interface"] = "missing"
+    home_data = EnvoyInterfaceInformation.from_api(home_json)
+    assert home_data is None
+
+    # test handling missing interfaces part
+    del home_json["network"]["interfaces"]
+    home_data = EnvoyInterfaceInformation.from_api(home_json)
+    assert not home_data
+
+    # test handling missing network part
+    del home_json["network"]
+    home_data = EnvoyInterfaceInformation.from_api(home_json)
+    assert not home_data
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_interface_settings_with_7_6_175():
+    """Test home interface information data"""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+
+    # start with regular data first
+    version = "7.6.175"
+    start_7_firmware_mock()
+    await prep_envoy(version)
+
+    # details of this test is done elsewhere already, just check data is returned
+    envoy = await get_mock_envoy()
+    data = envoy.data
+    assert data is not None
+
+    # test interface_settings method
+    home_data: EnvoyInterfaceInformation | None = await envoy.interface_settings()
+
+    # validate common data
+    assert home_data
+    assert home_data.software_build_epoch == 1719503966
+    assert home_data.dhcp
+    assert home_data.timezone == "Europe/Amsterdam"
+
+    # validate interface data
+    assert home_data.mac == "00:1D:C0:7F:B6:3B"
+    assert home_data.primary_interface == "eth0"
+    assert home_data.interface_type == "ethernet"
+
+    # load mock data for home endpoint
+    home_json = await load_json_fixture(version, "home")
+    # Change mock to use wlan interface
+    home_json["network"]["primary_interface"] = "wlan0"
+    # and mock new data
+    respx.get("/home").mock(return_value=Response(200, json=home_json))
+
+    # get interface data, subsequent call data is returned from cache
+    home_data = await envoy.interface_settings()
+
+    # interface data should come from cache and still be the same
+    assert home_data
+    assert home_data.mac == "00:1D:C0:7F:B6:3B"
+    assert home_data.primary_interface == "eth0"
+    assert home_data.interface_type == "ethernet"
+
+    # call setup to invalidate cached interface data
+    await envoy.setup()
+
+    # now interface data should be reflect latest mocked data and reflect wlan interface
+    home_data = await envoy.interface_settings()
+    assert home_data
+    assert home_data.mac == "60:E8:5B:AB:9D:64"
+    assert home_data.primary_interface == "wlan0"
+    assert home_data.interface_type == "wifi"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_home_endpoint_errors_with_7_6_175(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test home interface information data"""
+    logging.getLogger("pyenphase").setLevel(logging.DEBUG)
+    caplog.set_level(logging.DEBUG)
+
+    # start with regular data first
+    version = "7.6.175"
+    start_7_firmware_mock()
+    await prep_envoy(version)
+
+    # details of this test is done elsewhere already, just check data is returned
+    envoy = await get_mock_envoy()
+    data = envoy.data
+    assert data is not None
+
+    # test not-found error
+    respx.get("/home").mock(return_value=Response(404))
+    await envoy.interface_settings()
+    assert "Failure getting interface information" in caplog.text
+    caplog.clear()
+
+    # test server error
+    respx.get("/home").mock(return_value=Response(500))
+    await envoy.interface_settings()
+    assert "Failure getting interface information" in caplog.text
+    caplog.clear()
+
+    respx.get("/home").mock(return_value=Response(200, text="")).side_effect = [
+        httpx.NetworkError("Test Networkerror"),
+    ]
+    await envoy.interface_settings()
+    assert "Failure getting interface information" in caplog.text
+    caplog.clear()
+
+    respx.get("/home").mock(return_value=Response(200, text="")).side_effect = [
+        httpx.RemoteProtocolError("Test protocolerror"),
+    ]
+    with pytest.raises(httpx.RemoteProtocolError):
+        await envoy.interface_settings()
+
+    respx.get("/home").mock(return_value=Response(200, text="")).side_effect = [
+        httpx.TimeoutException("Test timeoutexception"),
+    ]
+    await envoy.interface_settings()
+    assert "Failure getting interface information" in caplog.text


### PR DESCRIPTION
This PR add a new method to the Envoy class that returns information about the active network interface in the Envoy. The data returned by the method is:

```python
primary_interface: str  #: name of primary (active) interface
mac: str  #: mac of primary interface, "unknown" if missing
interface_type: str  #: primary interface type, "unknown" if missing
dhcp: bool  #: interfaces uses DHCP, False if missing
software_build_epoch: int  #: envoy software build time, 0 if missing
timezone: str  #: Timezone set in Envoy, "unknown" if missing
```

The data is sourced from the /home endpoint. This is a slower endpoint and, when used often, may have impact on the Envoy resources. Therefore the data collection is not part of the typical updater structure but made available as a seperate method.

The method will request the data on first use and cache the data. Subsequent calls are fulfilled from this cache. As the data is static this avoid unintended polling of the endpoint. The cached data will be invalidated when envoy.setup is called and the next call to the method will load the information from the envoy into the cache again.

Tests and documentation is included as well.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving and caching detailed network interface information from the Envoy device, including DHCP status, MAC address, interface type, software build epoch, and timezone.
- **Documentation**
  - Updated documentation to include details about the new interface data feature.
- **Tests**
  - Introduced comprehensive tests for the new interface information model and endpoint handling, covering normal, edge, and error scenarios.
  - Added test fixtures for simulating realistic device responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->