### PR TITLE
fix: pass middleware as a tuple

### DIFF
--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -366,7 +366,7 @@ class Envoy:
             request_start = time.monotonic()
 
         # Set up middleware from auth
-        middlewares = self.auth.auth
+        middlewares = (self.auth.auth,) if self.auth.auth else None
 
         # not using redirects to avoid following 301s to error pages on missing
         # end points and lots of extra requests


### PR DESCRIPTION
fixes
```
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/pyenphase/envoy.py", line 293, in probe_request
    return await self._request(endpoint)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/pyenphase/envoy.py", line 389, in _request
    response = await self._client.get(
               ^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client.py", line 754, in _request
    handler = build_client_middlewares(
        _connect_and_send_request, effective_middlewares
    )
  File "/usr/local/lib/python3.13/site-packages/aiohttp/client_middlewares.py", line 32, in build_client_middlewares
    if len(middlewares) == 1:
       ~~~^^^^^^^^^^^^^
TypeError: object of type DigestAuthMiddleware has no len()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of authentication middleware to ensure more reliable request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->