### PR TITLE
chore: add insertion flag to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+<!-- version list -->
 
 ## v2.0.1 (2025-06-07)
 


### PR DESCRIPTION
Version 2.1 ci release action did not update the changelog.md with the commit information.

Version 2.1 included [282](https://github.com/pyenphase/pyenphase/pull/282), [249f2c7](https://github.com/pyenphase/pyenphase/commit/249f2c77460bc9f586b4d3f17d410b37e58e2a94) that updated python-semantic-release/publish-action from 9.21.0 to 10.0.2. That update changed default setting of[ changelog mode](https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration.html#mode) from init to update. Update mode seems to [require an insertion flag](https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration.html#insertion-flag).

This PR adds the default insertion flag `<!-- version list -->` to changelog.md.

Not sure if update will also add the missing 2.1 changes. If not we may need to set the mode to init which causes the changelog to be rebuild each time. That was the default mode before 10.0.

