### PR TITLE
fix: set change log mode to init to regenerate missed 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ version_toml = ["pyproject.toml:project.version", "pyproject.toml:tool.poetry.ve
 version_variables = ["src/pyenphase/__init__.py:__version__"]
 build_command = "pip install poetry && poetry build"
 
+[tool.semantic_release.changelog]
+mode = "init"
+
 [tool.pytest.ini_options]
 addopts = "-v -Wdefault --cov=pyenphase --cov-report=term-missing:skip-covered --timeout=5"
 pythonpath = ["src"]


### PR DESCRIPTION
Version 2.1 ci release action did not update the changelog.md with the commit information.

#290 added insertion flag to changelog but was a chore pr that did not trigger the changelog either.

#291 forced a changelog build by using a fix with empty commit. That generated the changelog but only added 2.1.1, but not the missing prior 2.1.

This PR is added the [tool.semantic_release.changelog.mode](https://python-semantic-release.readthedocs.io/en/latest/upgrading/10-upgrade.html#default-configuration-changes) to pyproject.toml and set mode to "init". In this mode it should rebuild full changelog each time and add the missing 2.1 changelog. If this results in a full changelog again, mode can be set back to "update".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to support changelog generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->