### PR TITLE
fix: early v7 firmware returns 401 on production probe with aiohttp.

### DIFF
--- a/src/pyenphase/updaters/production.py
+++ b/src/pyenphase/updaters/production.py
@@ -70,7 +70,7 @@ class EnvoyProductionUpdater(EnvoyUpdater):
                     e,
                 )
                 return None
-            _LOGGER.debug(   # pragma: no cover
+            _LOGGER.debug(  # pragma: no cover
                 "Authentication required for %s, re-raising exception: %s",
                 self.end_point,
                 e,


### PR DESCRIPTION
After switch from httpx to aiohhtp, an early v7 firmware version (7.0.88) for non-metered Envoy returns a 401 when probing /production.json?details=1. 

This PR changes production probe to not raise authentication error when this occurs but return none as if the endpoint doesn't exist. If it is truly an authentication error the fallback to the v1 production endpoint will trigger the authentication issue.

Reported in HA [#148028](https://github.com/home-assistant/core/issues/148028)

Debug logs of HA integration load for HA 2025.6.3 and 2025.7.1 shows the 2025.6.3 version successful reading the endpoint

```
2025-07-05 16:44:47.250 DEBUG (MainThread) [pyenphase.envoy] Requesting https://192.168.1.60/ivp/meters with timeout Timeout(connect=10.0, read=45.0, write=10.0, pool=10.0)
2025-07-05 16:44:47.266 DEBUG (MainThread) [pyenphase.envoy] Request reply in 0.0 sec from https://192.168.1.60/ivp/meters status 200: None b'[]'
2025-07-05 16:44:47.267 DEBUG (MainThread) [pyenphase.updaters.meters] No CT Meters found
2025-07-05 16:44:49.119 DEBUG (MainThread) [pyenphase.envoy] Requesting https://192.168.1.60/production with timeout Timeout(connect=10.0, read=45.0, write=10.0, pool=10.0)
2025-07-05 16:44:51.260 DEBUG (MainThread) [pyenphase.envoy] Request reply in 2.1 sec from https://192.168.1.60/production status 200: application/json b'{"production":[{"type":"inverters","activeCount":11,"readingTime":1751726522,"wNow":807,"whLifetime":523732}],"storage":[{"type":"acb","activeCount":0,"readingTime":0,"wNow":0,"whNow":0,"state":"idle"}]}'
2025-07-05 16:44:51.262 DEBUG (MainThread) [pyenphase.envoy] Requesting https://192.168.1.60/api/v1/production with timeout Timeout(connect=10.0, read=45.0, write=10.0, pool=10.0)
2025-07-05 16:44:51.288 DEBUG (MainThread) [pyenphase.envoy] Request reply in 0.0 sec from https://192.168.1.60/api/v1/production status 200: application/json b'{\n  "wattHoursToday": 14731,\n  "wattHoursSevenDays": 195426,\n  "wattHoursLifetime": 4102871,\n  "wattsNow": 807\n}\n'
```

while the 2025.7.1 one fails

```
2025-07-05 14:48:17.710 DEBUG (MainThread) [pyenphase.envoy] Requesting https://192.168.1.60/ivp/meters with timeout ClientTimeout(total=45.0, connect=10.0, sock_read=45.0, sock_connect=None, ceil_threshold=5)
2025-07-05 14:48:17.748 DEBUG (MainThread) [pyenphase.envoy] Request reply in 0.0 sec from https://192.168.1.60/ivp/meters status 200: None b'[]'
2025-07-05 14:48:17.749 DEBUG (MainThread) [pyenphase.updaters.meters] No CT Meters found
2025-07-05 14:48:17.749 DEBUG (MainThread) [pyenphase.envoy] Requesting https://192.168.1.60/production.json?details=1 with timeout ClientTimeout(total=45.0, connect=10.0, sock_read=45.0, sock_connect=None, ceil_threshold=5)
2025-07-05 14:48:17.780 DEBUG (MainThread) [pyenphase.envoy] Authentication failed for https://192.168.1.60/production.json?details=1 with status 401: b"<html>\r\n<head><title>401 Authorization Required</title></head>\r\n<body>\r\n<center><h1>401 Authorization Required</h1></center>\r\n<hr><center>Redirecting to <a id='link' href=''></a></center>\r\n<script>\r\nconst redirect_url = window.location.protocol + '//' + window.location.host + '/home';\r\nfunction redirect() { window.location.href = redirect_url; }\r\nwindow.onload = function() {\r\n    const link = document.getElementById('link');\r\n    link.href = redirect_url;\r\n    link.text = redirect_url;\r\n    setT"
2025-07-05 14:48:17.781 DEBUG (MainThread) [pyenphase.updaters.production] Authentication required for /production.json?details=1, re-raising exception: Authentication failed for https://192.168.1.60/production.json?details=1 with status 401, please check your username/password or token.
2025-07-05 14:48:17.782 DEBUG (MainThread) [pyenphase.firmware] Requesting https://192.168.1.60/info with timeout ClientTimeout(total=45.0, connect=10.0, sock_read=45.0, sock_connect=None, ceil_threshold=5)
2025-07-05 14:48:18.654 DEBUG (MainThread) [pyenphase.firmware] Request reply in 0.9 sec from https://192.168.1.60/info status 200: b"<?xml version='1.0' encoding='UTF-8'?>\n<envoy_info>\n  <time>1751719705</time>\n  <device>\n    <sn>122140044348</sn>\n    <pn>800-00656-r06</pn>\n    <software>D7.0.88</software>\n    <euaid>4c8675</euaid>\n    <seqnum>0</seqnum>\n    <apiver>1</apiver>\n    <imeter>false</imeter>\n  </device>\n  <web-tokens>true</web-tokens>\n  <package name='rootfs'>\n    <pn>500-00001-r01</pn>\n    <version>02.00.00</version>\n    <build>1210</build>\n  </package>\n  <package name='kernel'>\n    <pn>500-00011-r02</pn>\n    <version>04.04.225</version>\n    <build>d7c2e5</build>\n  </package>\n  <package name='boot'>\n    <pn>590-00019-r01</pn>\n    <version>02.00.01</version>\n    <build>1f421b</build>\n  </package>\n  <package name='app'>\n    <pn>500-00002-r01</pn>\n    <version>07.00.88</version>\n    <build>5580b1</build>\n  </package>\n  <package name='devimg'>\n    <pn>500-00005-r01</pn>\n    <version>01.02.371</version>\n    <build>373aab</build>\n  </package>\n  <package name='geo'>\n    <pn>500-00008-r01</pn>\n    <version>02.01.24</version>\n    <build>a74d96</build>\n  </package>\n  <package name='backbone'>\n    <pn>500-00010-r01</pn>\n    <version>07.00.20</version>\n    <build>176d57</build>\n  </package>\n  <package name='meter'>\n    <pn>500-00013-r01</pn>\n    <version>03.02.08</version>\n    <build>4f713a</build>\n  </package>\n  <package name='agf'>\n    <pn>500-00012-r01</pn>\n    <version>02.02.00</version>\n    <build>c62cdb</build>\n  </package>\n  <package name='security'>\n    <pn>500-00016-r01</pn>\n    <version>02.00.00</version>\n    <build>54a6dc</build>\n  </package>\n  <package name='patch'>\n    <pn>500-00016-r01</pn>\n    <version>01.00.00</version>\n    <build>256</build>\n  </package>\n  <package name='essimg'>\n    <pn>500-00020-r01</pn>\n    <version>21.19.82</version>\n    <build>667fd7</build>\n  </package>\n  <package name='full'>\n    <pn>500-00001-r01</pn>\n    <version>02.00.00</version>\n    <build>1210</build>\n  </package>\n  <build_info>\n    <build_id>ec2-user-envoy_uber-pkg_master:pkg-Feb-24-22-19:35:10</build_id>\n    <build_time_gmt>1645731441</build_time_gmt>\n    <release_ver>02.00.2267</release_ver>\n    <release_stage>700-GA</release_stage>\n  </build_info>\n</envoy_info>\n"
```

No clear indication for why this fails with aiohttp versus the prvious httpx version. Early versions of the v7 firmware are known for some unexpected responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication errors for certain production endpoints, ensuring better compatibility with early non-metered V7 versions.

* **Documentation**
  * Updated comments to clarify error handling behavior and fallback logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->