### PR TITLE
fix: fallback to v1 inverter endpoint if number of installed inverters exceed deviceDataLimit

### DIFF
--- a/src/pyenphase/updaters/device_data_inverters.py
+++ b/src/pyenphase/updaters/device_data_inverters.py
@@ -45,6 +45,28 @@ class EnvoyDeviceDataInvertersUpdater(EnvoyUpdater):
                 e,
             )
             return None
+        # make sure deviceCount did not reach deviceDataLimit,
+        # if more inverters are actually installed they will not be included
+        # if so fall back to inverter production page
+        try:
+            if inverters_data["deviceCount"] >= inverters_data["deviceDataLimit"]:
+                _LOGGER.debug(
+                    "Disabling inverters device data endpoint "
+                    " as deviceCount reached  deviceDataLimit %s: %s - %s",
+                    URL_DEVICE_DATA,
+                    inverters_data["deviceCount"],
+                    inverters_data["deviceDataLimit"],
+                )
+                return None
+        except KeyError as e:
+            # if doesn't have these keys, fall back to inverter production
+            _LOGGER.debug(
+                "Disabling inverters device data endpoint "
+                " as not all data fields are present %s: %s",
+                URL_DEVICE_DATA,
+                e,
+            )
+            return None
 
         # verify minimal data set to replace inverter production data is present
         try:


### PR DESCRIPTION
The inverter data report sourced from /ivp/pdm/device_data only reports up to deviceDataLimit inverters. If more inverters are installed these are excluded from the report. If that happens they no longer show in the inverter data record (and subsequantly in HA).

```json
"deviceCount": 50,
"deviceDataLimit": 50
```
It's not clear if this is a configuration omission or just a structural Envoy limitation.

This PR will let the inverter reporting fallback to the /api/v1/production/inverters endpoint if deviceCount has reached deviceDataLimit. This will result in pre 2.1.0 behavior for inverters.

HA Issue report: https://github.com/home-assistant/core/issues/148331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the device count reaches or exceeds the device data limit, or when required fields are missing, ensuring a reliable fallback to alternative data sources for inverter data.

* **Tests**
  * Expanded test coverage to verify correct fallback behavior when device data limits are reached or when essential fields are missing in the inverter device data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->