### PR TITLE
docs: re-add request response description

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,4 +1,6 @@
-# Updater modification
+# Customizations
+
+Some options to customize the library behavior are available. This allows to add or remove [updaters](./updaters.md) to provide alternate sources for {py:class}`pyenphase.EnvoyData` or add new data to the {py:class}`raw data<pyenphase.EnvoyData.raw>`.
 
 ## Register updater
 

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -8,7 +8,7 @@ await envoy.setup()
 await envoy.authenticate(username=username, password=password, token=token)
 
 myresponse: aiohttp.ClientResponse = await envoy.request('/my/own/endpoint')
-status_code = myresponse.status_code
+status_code = myresponse.status
 
 myjson_data = await myresponse.json()
 
@@ -23,7 +23,7 @@ You can run the package using {py:meth}`Envoy.request() <pyenphase.Envoy.request
 
 [^1]: This is a breaking change from version 1 where an httpx.Response was returned.
 
-To access the response data use either [aiohttp.ClientResponse.read()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.read) to access the whole response body as bytes, [aiohttp.ClientResponse.text()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.text) to get response body as decoded `str` or [aiohttp.ClientResponse.json()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.json) to read the body as JSON.
+To access the response data, use [aiohttp.ClientResponse.read()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.read) for the raw bytes, [aiohttp.ClientResponse.text()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.text) for a decoded `str`, or [aiohttp.ClientResponse.json()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.json) for a parsed JSON object.
 
 Note that `ClientResponse.json()` uses Python’s standard decoder `json.loads` by default. To use a different decoder, pass it via the `loads=` parameter, for example:
 

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -15,14 +15,19 @@ myjson_data = await myresponse.json()
 envoy.close()
 ```
 
-You can run the package using {py:meth}`requests <pyenphase.Envoy.request>` only (without calling [probe](usage_intro.md#probe) and [update](usage_intro.md#update)), which provides an API into the Envoy without using the internally pre-configured data collections.
+You can run the package using {py:meth}`Envoy.request() <pyenphase.Envoy.request>` only (without calling [probe](usage_intro.md#probe) and [update](usage_intro.md#update)), which provides an API into the Envoy without using the internally pre-configured data collections.
 
 ## ClientResponse
 
-{py:meth}`Envoy.request() <pyenphase.Envoy.request>` returns an [aiohttp.ClientResponse](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse) as result. [^1]
+{py:meth}`Envoy.request() <pyenphase.Envoy.request>` returns an [aiohttp.ClientResponse](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse) as the result. [^1]
 
 [^1]: This is a breaking change from version 1 where an httpx.Response was returned.
 
 To access the response data use either [aiohttp.ClientResponse.read()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.read) to access the whole response body as bytes, [aiohttp.ClientResponse.text()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.text) to get response body as decoded `str` or [aiohttp.ClientResponse.json()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.json) to read the body as JSON.
 
-Note that the JSON method is the standard python decoder JSON.loads. To use another one use the read() method in combination with your favorite decoder.
+Note that `ClientResponse.json()` uses Python’s standard decoder `json.loads` by default. To use a different decoder, pass it via the `loads=` parameter, for example:
+
+```python
+import orjson
+myjson_data = await myresponse.json(loads=orjson.loads)
+```

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -12,13 +12,16 @@ status_code = myresponse.status_code
 
 myjson_data = await myresponse.json()
 
+envoy.close()
 ```
 
-You can run the package using requests only (without calling probe and update), which provides an API into the Envoy without using the internally pre-configured data collections.
+You can run the package using {py:meth}`requests <pyenphase.Envoy.request>` only (without calling [probe](usage_intro.md#probe) and [update](usage_intro.md#update)), which provides an API into the Envoy without using the internally pre-configured data collections.
 
-## V2 Request
+## ClientResponse
 
-As of version 2, envoy.request returns an [aiohttp.ClientResponse](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse) as result. This is a breaking change from version 1 where an httpx.Response was returned.
+{py:meth}`Envoy.request() <pyenphase.Envoy.request>` returns an [aiohttp.ClientResponse](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse) as result. [^1]
+
+[^1]: This is a breaking change from version 1 where an httpx.Response was returned.
 
 To access the response data use either [aiohttp.ClientResponse.read()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.read) to access the whole response body as bytes, [aiohttp.ClientResponse.text()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.text) to get response body as decoded `str` or [aiohttp.ClientResponse.json()](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientResponse.json) to read the body as JSON.
 


### PR DESCRIPTION
Managed to undo a doc change in the course a previous pr. This pr re-adds the doc change to rename some headers and text in requests.md and advanced.md.

- V2 Request -> ClientResponse 
  - description of client response
  - move V2 change awareness to footnote
- Updater modification  -> Customizations
  - introduction to customization options


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Renamed and expanded the “Customizations” section with a descriptive intro and guidance for extending or adjusting data sources.
  - Updated request examples to explicitly close connections after reading responses.
  - Clarified the request API’s return type, noted the breaking change from v1, and improved cross-references to related pages.
  - Added guidance on JSON decoding, including using alternative decoders via reading the raw payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->