### PR TITLE
refactor: add generic empty data structures for CT data

### DIFF
--- a/src/pyenphase/models/envoy.py
+++ b/src/pyenphase/models/envoy.py
@@ -60,6 +60,13 @@ class EnvoyData:
     system_net_consumption_phases: dict[str, EnvoySystemConsumption | None] | None = (
         None
     )
+    #: CT power & energy values , only for Envoy metered with CT installed
+    ctmeters: dict[str, EnvoyMeterData] = field(default_factory=dict)  #: CT Meter data
+    #: CT power & energy phase values , only for Envoy metered with CT installed
+    ctmeters_phases: dict[str, dict[str, EnvoyMeterData]] = field(
+        default_factory=dict
+    )  #: CT Meter phase data
+    # these are still here for backward compatibility
     #: Production CT power & energy values , only for Envoy metered with production CT installed
     ctmeter_production: EnvoyMeterData | None = None  #: Production CT Meter data
     #: Consumption CT power & energy values , only for Envoy metered with consumption CT installed

--- a/tests/__snapshots__/test_acb.ambr
+++ b/tests/__snapshots__/test_acb.ambr
@@ -107,6 +107,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -920,6 +924,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -1380,6 +1388,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -2363,6 +2375,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -3280,6 +3296,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -4587,6 +4607,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -5990,6 +6014,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': None,
@@ -7701,6 +7729,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -8530,6 +8562,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -9477,6 +9513,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -10313,6 +10353,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -12023,6 +12067,10 @@
         'timestamp': 1709829517,
         'voltage': 121.248,
       }),
+    }),
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
     }),
     'dry_contact_settings': dict({
       'NC1': dict({
@@ -13793,6 +13841,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -15339,6 +15391,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({

--- a/tests/__snapshots__/test_endpoints.ambr
+++ b/tests/__snapshots__/test_endpoints.ambr
@@ -107,6 +107,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -920,6 +924,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -1921,6 +1929,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -2381,6 +2393,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -3236,6 +3252,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -3891,6 +3911,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -4808,6 +4832,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -6115,6 +6143,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -7518,6 +7550,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': None,
@@ -9199,6 +9235,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -9544,6 +9584,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -9889,6 +9933,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -10487,6 +10535,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -11215,6 +11267,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -12044,6 +12100,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -12991,6 +13051,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -13827,6 +13891,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -15537,6 +15605,10 @@
         'timestamp': 1709829517,
         'voltage': 121.248,
       }),
+    }),
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
     }),
     'dry_contact_settings': dict({
       'NC1': dict({
@@ -17307,6 +17379,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -18813,6 +18889,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -19475,6 +19555,10 @@
         'timestamp': 1722967007,
         'voltage': 123.696,
       }),
+    }),
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
     }),
     'dry_contact_settings': dict({
       'NC1': dict({
@@ -21910,6 +21994,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,

--- a/tests/__snapshots__/test_ensemble.ambr
+++ b/tests/__snapshots__/test_ensemble.ambr
@@ -107,6 +107,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -920,6 +924,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -1921,6 +1929,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -2381,6 +2393,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -3236,6 +3252,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -3891,6 +3911,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -4808,6 +4832,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -6115,6 +6143,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -7518,6 +7550,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': None,
@@ -9199,6 +9235,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -9544,6 +9584,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -9889,6 +9933,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -10487,6 +10535,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -11215,6 +11267,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -12044,6 +12100,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -12991,6 +13051,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -13827,6 +13891,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -15537,6 +15605,10 @@
         'timestamp': 1709829517,
         'voltage': 121.248,
       }),
+    }),
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
     }),
     'dry_contact_settings': dict({
       'NC1': dict({
@@ -17307,6 +17379,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -18813,6 +18889,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -19475,6 +19555,10 @@
         'timestamp': 1722967007,
         'voltage': 123.696,
       }),
+    }),
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
     }),
     'dry_contact_settings': dict({
       'NC1': dict({
@@ -21910,6 +21994,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -24048,6 +24136,10 @@
         'timestamp': 1752974752,
         'voltage': 119.923,
       }),
+    }),
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
     }),
     'dry_contact_settings': dict({
     }),

--- a/tests/__snapshots__/test_net_consumption.ambr
+++ b/tests/__snapshots__/test_net_consumption.ambr
@@ -107,6 +107,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -920,6 +924,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -1921,6 +1929,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -2381,6 +2393,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -3236,6 +3252,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -3891,6 +3911,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -4808,6 +4832,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -6115,6 +6143,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -7518,6 +7550,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': None,
@@ -9199,6 +9235,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -9544,6 +9584,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -9889,6 +9933,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -10487,6 +10535,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -11215,6 +11267,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -12044,6 +12100,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -12991,6 +13051,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
     }),
     'dry_contact_status': dict({
@@ -13827,6 +13891,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -15537,6 +15605,10 @@
         'timestamp': 1709829517,
         'voltage': 121.248,
       }),
+    }),
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
     }),
     'dry_contact_settings': dict({
       'NC1': dict({
@@ -17307,6 +17379,10 @@
     }),
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,
@@ -18843,6 +18919,10 @@
     'ctmeter_production_phases': None,
     'ctmeter_storage': None,
     'ctmeter_storage_phases': None,
+    'ctmeters': dict({
+    }),
+    'ctmeters_phases': dict({
+    }),
     'dry_contact_settings': dict({
       'NC1': dict({
         'black_start': 5.0,


### PR DESCRIPTION
Envoy Firmware 8.3.1598 running in a combiner installation reports 4 new CT measurement types and data in ivp/meters endpoint. They may be all present or not; show status enabled or disabled. This PR is part of a sequence of changes to optimize support for CT and add these new CT types.

```json

  "state": "enabled",
  "measurementType": "backfeed",

  "state": "disabled",
  "measurementType": "load",

  "state": "disabled",
  "measurementType": "evse",

  "state": "disabled",
  "measurementType": "pv3p",
```
This PR adds ctmeters[meterType,EnvoyMeterData] and ctmeters_phases[meterType[phase,EnvoyMeterData]] to EnvoyData for future store of all ct types data.

Detailed changes:

- models/envoy.py
  - Add new data structures
- Tests/__snapshots__/
  - new empty record snapshots
    - Test_acb.ambr
    - Test_endpoints.ambr
    - Test_ensemble.ambr
    - Test_net_consumption.ambr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added CT meter and per-phase data fields to Envoy data, enabling representation of meters and their phases. Defaults to empty when no data is available. Existing behavior remains unchanged.

- Tests
  - Updated test snapshots to include the new CT meter and per-phase fields as empty dictionaries where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->