### PR TITLE
test: jwt short key warning in auth test

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -480,7 +480,7 @@ async def test_token_with_7_6_175_standard(
 
     token = jwt.encode(
         payload={"name": "envoy", "exp": 1707837780, "enphaseUser": "owner"},
-        key="secret",
+        key="useaverylongsecretofatleast32bytestoavoidajwtsecuritywarning",
         algorithm="HS256",
     )
 


### PR DESCRIPTION
Since latest pyjwt update, test_auth.py shows a warning:

```
tests/test_auth.py::test_token_with_7_6_175_standard
  /home/arie/dev/pyenphase_dev/.venv/lib/python3.12/site-packages/jwt/api_jwt.py:147: InsecureKeyLengthWarning: The HMAC key is 6 bytes long, which is below the minimum recommended length of 32 bytes for SHA256. See RFC 7518 Section 3.2.
```

This PR extends the key used by test_auth.py in jwt.encode to resolve the warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test authentication to use enhanced key security, eliminating warnings in test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->