### PR TITLE
fix: set opt_schedules=False when changing storage mode

### DIFF
--- a/docs/data_ensemble.md
+++ b/docs/data_ensemble.md
@@ -76,6 +76,13 @@ The Envoy class provides the methods [Envoy.enable_charge_from_grid](#pyenphase.
         print(f"{envoy.data.tariff.data.tariff.storage_settings.mode}")
         print (status)
 
+```
+
+On firmware where optimized schedules are supported, passing `disable_optimized_schedules=True` to `set_storage_mode` will also set `opt_schedules` to `False`. When `opt_schedules` is `True`, writes to `storage_settings.mode` are accepted by the gateway and return HTTP 200, but are silently ignored by the battery controller.
+
+Note that the Enlighten cloud service may overwrite a locally-set mode within one to two minutes by pushing its own tariff configuration to the gateway. See [Known Issues](./known_issues.md#enlighten-cloud-overwriting-locally-set-battery-mode) for details.
+
+```python
         status = await envoy.set_reserve_soc(value: int)
         print(f"{envoy.data.tariff.storage_settings.reserved_soc}")
         print (status)

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -27,3 +27,11 @@ Each day, shortly after 11 PM local Envoy time, the Envoy performs some internal
 Pyenphase uses retries when a request fails. Default retry setup is no more than 240 seconds elapsed, or 6 attempts. Each try uses the timeout specified in {py:class}`pyenphase.Envoy` or a 45 seconds default. With the default timeout of 45 seconds, this results in maximum 6 attempts, 5 retries. Or up to 6 attempts if the failure occurs quicker.
 
 If this 11 PM outage still results in errors, use the {py:meth}`pyenphase.Envoy.set_retry_policy` method to set a more relaxed retry scheme.
+
+(battery-mode-overwritten)=
+
+## Enlighten cloud overwriting locally-set battery mode
+
+The IQ Gateway maintains a persistent outbound connection to the Enlighten cloud service, which periodically uses this connection to push tariff configuration to the gateway. When a local API write via {py:meth}`pyenphase.Envoy.set_storage_mode` sets a mode that differs from the cloud-held configuration, the cloud will typically overwrite it within one to two minutes. The overwrite is identifiable in the tariff response: the `date` field is updated to a timestamp that was not written by the local PUT request, `opt_schedules` is restored to `true`, and the mode reverts to `self-consumption`. Enphase have confirmed this behaviour is intentional.
+
+Blocking the IQ Gateway's outbound internet access at the network level prevents the cloud push and causes locally-set modes to persist. Note that this also prevents the Enlighten platform from receiving monitoring data from the gateway, and may lead to unexpected behaviour when sustained over long periods of time.

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -1080,7 +1080,11 @@ class Envoy:
             URL_TARIFF, {"tariff": self.data.tariff.to_api()}, method="PUT"
         )
 
-    async def set_storage_mode(self, mode: EnvoyStorageMode) -> dict[str, Any]:
+    async def set_storage_mode(
+        self,
+        mode: EnvoyStorageMode,
+        disable_optimized_schedules: bool = False,
+    ) -> dict[str, Any]:
         """
         Set the Encharge storage mode.
 
@@ -1089,7 +1093,17 @@ class Envoy:
         using PUT. This will update the storage mode setting
         in the Envoy.
 
+        On firmware where optimized schedules are supported, set
+        ``disable_optimized_schedules=True`` to also set ``opt_schedules``
+        to ``False`` alongside the mode change. When ``opt_schedules`` is
+        ``True``, writes to ``storage_settings.mode`` are accepted by the
+        gateway and return HTTP 200, but are silently ignored by the battery
+        controller. See :ref:`battery-mode-overwritten` for details on cloud reconciliation
+        behaviour when the gateway has internet access.
+
         :param mode: storage mode to set
+        :param disable_optimized_schedules: set ``opt_schedules`` to ``False``
+            alongside the mode change
         :raises EnvoyFeatureNotAvailable: If no Encharge or IQ batteries are available
         :raises EnvoyFeatureNotAvailable: If no TARIFF data is available in Envoy
         :raises EnvoyCommunicationError: when aiohttp network or communication error occurs.
@@ -1105,6 +1119,11 @@ class Envoy:
         if type(mode) is not EnvoyStorageMode:
             raise TypeError("Mode must be of type EnvoyStorageMode")
         self.data.tariff.storage_settings.mode = mode
+        if (
+            disable_optimized_schedules
+            and self.data.tariff.storage_settings.opt_schedules is not None
+        ):
+            self.data.tariff.storage_settings.opt_schedules = False
         return await self._json_request(
             URL_TARIFF, {"tariff": self.data.tariff.to_api()}, method="PUT"
         )

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -723,6 +723,20 @@ async def test_with_7_x_firmware(
         _cnt, request_data = latest_request(mock_aioresponse, "PUT", URL_TARIFF)
         assert orjson.loads(request_data) == {"tariff": data.tariff.to_api()}
 
+        await envoy.set_storage_mode(
+            EnvoyStorageMode.SELF_CONSUMPTION, disable_optimized_schedules=True
+        )
+        assert data.tariff.storage_settings.mode == EnvoyStorageMode.SELF_CONSUMPTION
+        _cnt, request_data = latest_request(mock_aioresponse, "PUT", URL_TARIFF)
+        assert orjson.loads(request_data) == {"tariff": data.tariff.to_api()}
+        if data.tariff.storage_settings.opt_schedules is not None:
+            assert (
+                orjson.loads(request_data)["tariff"]["storage_settings"][
+                    "opt_schedules"
+                ]
+                is False
+            )
+
         with pytest.raises(TypeError):
             await envoy.set_storage_mode("invalid")  # type: ignore[arg-type]
 


### PR DESCRIPTION
I've been using Home Assistant with an Enphase Envoy gateway since March (firmware D8.3.5169) but have been unable to change battery storage mode via the HA select entity. The change appeared to succeed, the UI updated but the battery never actually changed behaviour. Switching between self-consumption, backup and savings mode had no visible effect.

I ruled out the HA integration by testing the `/admin/lib/tariff` endpoint directly with cURL using a JWT from the Enphase cloud. Reading the tariff showed my gateway had `opt_schedules: true` in `storage_settings`. When I issued a PUT with a new mode but left `opt_schedules: true` in the body, the gateway responded 200 and reflected the new mode back in `storage_settings` - but `schedule.batt_mode` remained unchanged and the battery controller continued following the old mode. When I repeated the PUT with `opt_schedules: false` included, both `storage_settings.mode` and `schedule.batt_mode` updated correctly, and the battery changed behaviour as expected.

The gateway appears to use `opt_schedules` as a flag indicating the schedule layer is active and should take precedence. When it is `true`, writes to `mode` are accepted but effectively ignored by the battery controller.

I have tested the fix in this PR on my local Home Assistant by using my pyenphase fork in the Enphase core integration (set up as a custom_component), it restores the battery profile select functionality, however the change is silently reverted to `self-consumption` after a short and variable delay, typically one to two minutes. Enabling debug logging on the Enphase integration confirmed the local PUT succeeds and Home Assistant reads back the updated state, but within roughly a minute it reads a new tariff in which the mode has been reset, `opt_schedules` has been restored to `true`, and the `date` field has been updated to a fresh timestamp that was not written by my PUT. No corresponding write was made by Home Assistant or any local process during that window. To confirm the source, I temporarily blocked the gateway's outbound internet access at my firewall, at which point the revert stopped immediately and local writes persisted as expected.

I shared these findings with Enphase API support, who confirmed that cloud reconciliation overwriting locally-set values is intentional an they have no plans to change this behaviour. I am happy to share the correspondence if that would be useful.

I am not sure if my fix in this PR is suitable to be merged, I created my fork first and foremost to test my theory, and have been using it for a couple of days now (with a firewall block in place) and am happy with how it is working. I would like to start a discussion about how best to proceed? I think this fix could be beneficial to others under certain circumstances (willing to block the gateway from accessing the internet), but being new to pyenphase and the Enphase ecosystem as a whole, I'm not 100% sure about the implications of this change to the wider userbase? My concern is mostly on the potential to mislead people who use `set_storage_mode` under normal (internet connected) circumstances only to find it changes back after a minute or two, could that create more noise/confusion than it simply not working for some?

I'd really appreciate thoughts and feedback on this.

Many thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to explicitly disable optimized schedules when applying a battery storage mode.

* **Bug Fixes**
  * Storage mode updates now disable optimized schedules on supported devices to avoid the controller silently ignoring changes.

* **Documentation**
  * Clarified interaction between storage mode updates, optimized schedules, and device/firmware behavior.
  * Documented that the cloud may overwrite a locally set battery mode within 1–2 minutes and how to recognize this.

* **Tests**
  * Updated tests to cover behavior when optimized schedules are disabled during mode changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pyenphase/pyenphase/pull/432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->