### PR TITLE
ci: check out merge ref so release job works for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name }}
+          ref: ${{ github.ref }}
+
+      - name: Create local branch name
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: git switch -C "$BRANCH"
 
       # Do a dry run of PSR
       - name: Test release


### PR DESCRIPTION
## Summary

The release job currently checks out using `ref: ${{ github.head_ref || github.ref_name }}`, which on PRs from forks resolves to a branch name that does not exist on the upstream repo, so the checkout fails before the dry run can run; see the failure on #432. Switching to `github.ref` checks out the `pull/N/merge` ref, which is always reachable, then a follow-up `git switch -C "$BRANCH"` recreates the original branch name locally so python-semantic-release still sees the expected ref name.

## Test plan

- [ ] CI on this PR completes the release dry run successfully
- [ ] Re-run CI on #432 (or any future fork PR) and confirm the release job no longer errors with "branch or tag could not be found"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to fetch full git history during release processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pyenphase/pyenphase/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->