### PR TITLE
feat: add generator exercise-schedule and charge-from-generator write actions

### DIFF
--- a/docs/data_ensemble.md
+++ b/docs/data_ensemble.md
@@ -65,15 +65,23 @@ Systems with an Enpower and a standby generator installed report generator data.
 
 The Envoy class provides the method [Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) to control the generator operation mode, [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) to change the exercise schedule and default state-of-charge settings, and [Envoy.set_generator_charge_from_generator](#pyenphase.Envoy.set_generator_charge_from_generator) to allow or disallow charging batteries from the generator.
 
-Both methods send the whole document to the Envoy, as these endpoints do not support partial updates. The document is built from the data in [EnvoyData](#pyenphase.EnvoyData), with only the specified settings changed. [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) takes a dict of settings to change, so a single setting can be changed without specifying the others:
+[Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) and [Envoy.set_generator_charge_from_generator](#pyenphase.Envoy.set_generator_charge_from_generator) send the whole document to the Envoy, as these endpoints do not support partial updates. The document is built from the data in [EnvoyData](#pyenphase.EnvoyData), with only the specified settings changed. ([Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) is a single command endpoint and does not work this way.) [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) takes a dict of settings to change, so a single setting can be changed without specifying the others:
 
 ```python
 await envoy.update_generator_schedule({"exercise_day": "Sat", "exercise_start": 945})
 ```
 
-Both methods return the reply from the Envoy, which is the resulting document. The stored data is updated from it as well, so either can be used to verify what was applied.
+Both return the reply from the Envoy, which is the resulting document. The stored data is updated from it as well, so either can be used to verify what was applied. If the Envoy does not return a complete document, the stored data is left at the last known state instead of an optimistic one and `EnvoyCommunicationError` is raised; the update was sent in that case, so use [Envoy.update](#pyenphase.Envoy.update) to establish the actual state.
 
-On systems with Enphase batteries, note that `default_start_soc` and `default_stop_soc` are always part of the schedule document and are applied by the firmware as the active generator start/stop state of charge, as reported in [EnvoyData.generator](#pyenphase.EnvoyData.generator). Values held in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule) at the time of the call are sent, so if another application changed them since the last data collection, the update will set them back. Use [Envoy.update](#pyenphase.Envoy.update) first, or include the wanted SOC values in the settings to change.
+Both also accept `refresh`, which re-reads the document from the Envoy right before the changes are merged into it:
+
+```python
+await envoy.update_generator_schedule({"exercise_day": "Sat"}, refresh=True)
+```
+
+Use it when the Enphase cloud or app may have changed settings since the last data collection, so values from stale data are not sent back.
+
+On systems with Enphase batteries, note that `default_start_soc` and `default_stop_soc` are always part of the schedule document and are applied by the firmware as the active generator start/stop state of charge, as reported in [EnvoyData.generator](#pyenphase.EnvoyData.generator). Values held in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule) at the time of the call are sent, so if another application changed them since the last data collection, the update will set them back. Use `refresh=True`, call [Envoy.update](#pyenphase.Envoy.update) first, or include the wanted SOC values in the settings to change. The generator starts at `default_start_soc` and stops at `default_stop_soc`, so the start value must be lower than the stop value; the resulting pair is validated against the stored values for whichever of the two is not being changed.
 
 On systems without Enphase batteries the Envoy accepts a `charge_from_generator` write with HTTP 200 but normalizes the value back to `true`; do not assume `false` persisted. The returned document and the updated [EnvoyData.generator_config](#pyenphase.EnvoyData.generator_config) report the effective value.
 

--- a/docs/data_ensemble.md
+++ b/docs/data_ensemble.md
@@ -65,6 +65,8 @@ Systems with an Enpower and a standby generator installed report generator data.
 
 The Envoy class provides the method [Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) to control the generator operation mode, [Envoy.set_generator_exercise_schedule](#pyenphase.Envoy.set_generator_exercise_schedule) to change the exercise schedule, and [Envoy.set_generator_charge_from_generator](#pyenphase.Envoy.set_generator_charge_from_generator) to allow or disallow charging batteries from the generator.
 
+On systems without Enphase batteries the gateway accepts a `charge_from_generator` write with HTTP 200 but normalizes the value back to `true`; do not assume `false` persisted. The response body echoes the resulting effective configuration, so it can be compared with the request to detect this. Writing the exercise schedule also (re)applies the default start/stop state of charge, which matters on systems that do have batteries.
+
 ```python
 if envoy.data.generator:
     print(f"Generator relay: {envoy.data.generator.oper_state}")

--- a/docs/data_ensemble.md
+++ b/docs/data_ensemble.md
@@ -63,9 +63,19 @@ Systems with an Enpower and a standby generator installed report generator data.
 - The generator exercise schedule and default state-of-charge settings are available in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule), modeled by [EnvoyGeneratorSchedule](#pyenphase.models.generator.EnvoyGeneratorSchedule).
 - The generator operation mode ("off", "on" or "auto") is available in [EnvoyData.generator_mode](#pyenphase.EnvoyData.generator_mode), modeled by [EnvoyGeneratorMode](#pyenphase.models.generator.EnvoyGeneratorMode), on firmware exposing the `/ivp/ss/gen_mode` endpoint.
 
-The Envoy class provides the method [Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) to control the generator operation mode, [Envoy.set_generator_exercise_schedule](#pyenphase.Envoy.set_generator_exercise_schedule) to change the exercise schedule, and [Envoy.set_generator_charge_from_generator](#pyenphase.Envoy.set_generator_charge_from_generator) to allow or disallow charging batteries from the generator.
+The Envoy class provides the method [Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) to control the generator operation mode, [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) to change the exercise schedule and default state-of-charge settings, and [Envoy.set_generator_charge_from_generator](#pyenphase.Envoy.set_generator_charge_from_generator) to allow or disallow charging batteries from the generator.
 
-On systems without Enphase batteries the gateway accepts a `charge_from_generator` write with HTTP 200 but normalizes the value back to `true`; do not assume `false` persisted. The response body echoes the resulting effective configuration, so it can be compared with the request to detect this. Writing the exercise schedule also (re)applies the default start/stop state of charge, which matters on systems that do have batteries.
+Both methods send the whole document to the Envoy, as these endpoints do not support partial updates. The document is built from the data in [EnvoyData](#pyenphase.EnvoyData), with only the specified settings changed. [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) takes a dict of settings to change, so a single setting can be changed without specifying the others:
+
+```python
+await envoy.update_generator_schedule({"exercise_day": "Sat", "exercise_start": 945})
+```
+
+Both methods return the reply from the Envoy, which is the resulting document. The stored data is updated from it as well, so either can be used to verify what was applied.
+
+On systems with Enphase batteries, note that `default_start_soc` and `default_stop_soc` are always part of the schedule document and are applied by the firmware as the active generator start/stop state of charge, as reported in [EnvoyData.generator](#pyenphase.EnvoyData.generator). Values held in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule) at the time of the call are sent, so if another application changed them since the last data collection, the update will set them back. Use [Envoy.update](#pyenphase.Envoy.update) first, or include the wanted SOC values in the settings to change.
+
+On systems without Enphase batteries the Envoy accepts a `charge_from_generator` write with HTTP 200 but normalizes the value back to `true`; do not assume `false` persisted. The returned document and the updated [EnvoyData.generator_config](#pyenphase.EnvoyData.generator_config) report the effective value.
 
 ```python
 if envoy.data.generator:

--- a/docs/data_ensemble.md
+++ b/docs/data_ensemble.md
@@ -63,7 +63,7 @@ Systems with an Enpower and a standby generator installed report generator data.
 - The generator exercise schedule and default state-of-charge settings are available in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule), modeled by [EnvoyGeneratorSchedule](#pyenphase.models.generator.EnvoyGeneratorSchedule).
 - The generator operation mode ("off", "on" or "auto") is available in [EnvoyData.generator_mode](#pyenphase.EnvoyData.generator_mode), modeled by [EnvoyGeneratorMode](#pyenphase.models.generator.EnvoyGeneratorMode), on firmware exposing the `/ivp/ss/gen_mode` endpoint.
 
-The Envoy class provides the method [Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) to control the generator operation mode.
+The Envoy class provides the method [Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) to control the generator operation mode, [Envoy.set_generator_exercise_schedule](#pyenphase.Envoy.set_generator_exercise_schedule) to change the exercise schedule, and [Envoy.set_generator_charge_from_generator](#pyenphase.Envoy.set_generator_charge_from_generator) to allow or disallow charging batteries from the generator.
 
 ```python
 if envoy.data.generator:

--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -47,7 +47,19 @@ URL_GEN_SCHEDULE = "/ivp/ss/gen_schedule"
 #: Valid generator modes for :any:`Envoy.set_generator_mode`
 GENERATOR_MODES: frozenset[str] = frozenset({"off", "on", "auto"})
 
-#: Valid exercise days for :any:`Envoy.set_generator_exercise_schedule`,
+#: Settable generator schedule fields for :any:`Envoy.update_generator_schedule`
+GENERATOR_SCHEDULE_SETTINGS: frozenset[str] = frozenset(
+    {
+        "exercise_freq_in_weeks",
+        "exercise_day",
+        "exercise_start",
+        "exercise_duration",
+        "default_start_soc",
+        "default_stop_soc",
+    }
+)
+
+#: Valid exercise days for :any:`Envoy.update_generator_schedule`,
 #: in the capitalized short-day-name form the generator firmware reports
 GENERATOR_EXERCISE_DAYS: tuple[str, ...] = (
     "Mon",

--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -47,6 +47,18 @@ URL_GEN_SCHEDULE = "/ivp/ss/gen_schedule"
 #: Valid generator modes for :any:`Envoy.set_generator_mode`
 GENERATOR_MODES: frozenset[str] = frozenset({"off", "on", "auto"})
 
+#: Valid exercise days for :any:`Envoy.set_generator_exercise_schedule`,
+#: in the capitalized short-day-name form the generator firmware reports
+GENERATOR_EXERCISE_DAYS: tuple[str, ...] = (
+    "Mon",
+    "Tue",
+    "Wed",
+    "Thu",
+    "Fri",
+    "Sat",
+    "Sun",
+)
+
 # Meters data
 ENDPOINT_URL_METERS = "/ivp/meters"
 ENDPOINT_URL_METERS_READINGS = "/ivp/meters/readings"

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -1118,7 +1118,12 @@ class Envoy:
             short day name "Mon" through "Sun", any case
         :param start: exercise start time in minutes after
             midnight (0-1439)
-        :param duration: exercise duration in minutes, 1 or greater
+        :param duration: exercise duration in minutes, 10-60 in steps
+            of 10, matching the official Enphase app. Firmware accepts
+            and persists intermediate values (25 verified live on
+            D8.3.5169) but the Enlighten UI renders them as a blank
+            duration field, so the library enforces the vendor domain
+            to avoid writing values the official app cannot display.
         :raises EnvoyFeatureNotAvailable: If GENERATOR feature is not available in Envoy
         :raises EnvoyFeatureNotAvailable: If this firmware does not expose the gen_schedule endpoint
         :raises ValueError: If update was attempted before first data was requested from Envoy
@@ -1141,8 +1146,10 @@ class Envoy:
             )
         if not 0 <= start <= 1439:
             raise ValueError("start must be between 0 and 1439 minutes after midnight")
-        if duration < 1:
-            raise ValueError("duration must be 1 or greater")
+        if not 10 <= duration <= 60 or duration % 10 != 0:
+            raise ValueError(
+                "duration must be between 10 and 60 minutes in steps of 10"
+            )
         if not (data := self.data):
             raise ValueError(
                 "Tried to set generator exercise schedule before the Envoy was queried."

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -1107,11 +1107,14 @@ class Envoy:
         change and have status updated.
 
         .. note::
-            The request body shape is derived from the GET response shape
-            observed on live firmware (D8.2.127 and D8.3.5169) and has
-            not yet been verified against hardware. POST is used to match
-            the sibling /ivp/ss/ write endpoints (gen_mode,
-            dry_contact_settings).
+            The POST body shape round-trips the GET response shape and
+            was verified live on firmware D8.3.5169 (2026-07-30): writes
+            are accepted, persisted at the controller and synced to
+            Enlighten. POST matches the sibling /ivp/ss/ write endpoints
+            (gen_mode, dry_contact_settings). Writing the schedule also
+            (re)applies the echoed default_soc block as the ACTIVE
+            generator start/stop SOC settings — relevant on systems with
+            Enphase batteries.
 
         :param freq_in_weeks: exercise interval in weeks, 1-4, matching
             the official Enphase app's every-1-4-weeks domain (vendor UI
@@ -1199,11 +1202,15 @@ class Envoy:
         needs some time to implement the change and have status updated.
 
         .. note::
-            The request body shape is derived from the GET response shape
-            observed on live firmware (D8.2.127 and D8.3.5169) and has
-            not yet been verified against hardware. POST is used to match
-            the sibling /ivp/ss/ write endpoints (gen_mode,
-            dry_contact_settings).
+            The POST body shape round-trips the GET response shape and
+            matches the sibling /ivp/ss/ write endpoints (gen_mode,
+            dry_contact_settings). Verified live on firmware D8.3.5169
+            (2026-07-30): on systems without Enphase batteries the
+            firmware accepts the write (HTTP 200) but silently
+            normalizes charge_from_generator back to true. The response
+            body echoes the resulting EFFECTIVE configuration, so
+            callers can compare response to request to detect an
+            accepted-but-ignored write.
 
         :param charge_from_generator: True to allow charging batteries
             from the generator, False to disallow

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -1123,12 +1123,17 @@ class Envoy:
 
         The default_start_soc and default_stop_soc are applied by the
         firmware as the active generator start/stop SOC, as reported in
-        /ivp/ensemble/generator. They are always sent, so a schedule
-        update also (re)applies the SOC values held in
-        :any:`EnvoyData.generator_schedule` at the time of the call.
-        On systems with Enphase batteries, call :any:`Envoy.update`
-        first if another application may have changed them since the
-        last data collection.
+        /ivp/ensemble/generator. They are part of the schedule document
+        and are always sent, so an update also (re)applies the SOC
+        values held in :any:`EnvoyData.generator_schedule` at the time
+        of the call. On systems with Enphase batteries this matters
+        when the Enphase app or cloud changed them since the last data
+        collection, as the update would set them back to the values in
+        the stored data. Handle this in one of three ways: specify
+        refresh to re-read the schedule from the Envoy right before the
+        settings are merged into it, use :any:`Envoy.update` before the
+        call, or include the wanted SOC values in the settings to
+        change.
 
         The Envoy returns the resulting generator schedule, which is
         used to update :any:`EnvoyData.generator_schedule` and the raw
@@ -1138,11 +1143,6 @@ class Envoy:
         known state rather than at an optimistic one and
         EnvoyCommunicationError is raised. The update was sent in that
         case, use :any:`Envoy.update` to establish the actual state.
-
-        Specify refresh to re-read the schedule from the Envoy right
-        before the settings are merged into it. Use this when the
-        Enphase cloud or app may have changed settings since the last
-        data collection, to avoid sending values from stale data.
 
         :param new_data: dict of settings to change
         :param refresh: re-read the schedule from the Envoy before
@@ -1238,7 +1238,10 @@ class Envoy:
         are returned normalized where applicable.
 
         :param new_data: dict of settings to change
+        :param current: current generator schedule to validate the
+            settings to change against
         :raises ValueError: If an unknown setting is specified or a value is out of range
+        :raises ValueError: If the resulting default_start_soc is not lower than default_stop_soc
         :return: validated and normalized settings to change
         """
         if unknown := set(new_data) - GENERATOR_SCHEDULE_SETTINGS:
@@ -1313,11 +1316,14 @@ class Envoy:
         that case, use :any:`Envoy.update` to establish the actual
         state.
 
-        Specify refresh to re-read the configuration from the Envoy
-        right before the setting is changed in it. Use this when the
-        Enphase cloud or app may have changed the configuration since
-        the last data collection, to avoid sending values from stale
-        data.
+        The configuration is sent as a whole, so the values held in
+        :any:`EnvoyData.generator_config` at the time of the call are
+        sent along with the changed setting. If the Enphase app or
+        cloud changed the configuration since the last data collection,
+        the update would set it back to the values in the stored data.
+        Handle this by specifying refresh to re-read the configuration
+        from the Envoy right before the setting is changed in it, or by
+        using :any:`Envoy.update` before the call.
 
         :param charge_from_generator: True to allow charging batteries
             from the generator, False to disallow

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from functools import cached_property, partial
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 import aiohttp
 import orjson
@@ -85,6 +85,8 @@ from .updaters.production import (
 from .updaters.tariff import EnvoyTariffUpdater
 
 _LOGGER = logging.getLogger(__name__)
+
+_ModelT = TypeVar("_ModelT")
 
 
 DEFAULT_HEADERS = {
@@ -1085,7 +1087,7 @@ class Envoy:
         return result
 
     async def update_generator_schedule(
-        self, new_data: dict[str, Any]
+        self, new_data: dict[str, Any], refresh: bool = False
     ) -> dict[str, Any]:
         """
         Update the standby generator schedule settings.
@@ -1131,14 +1133,27 @@ class Envoy:
         The Envoy returns the resulting generator schedule, which is
         used to update :any:`EnvoyData.generator_schedule` and the raw
         data. Callers can use the returned data or the updated model to
-        verify the applied settings.
+        verify the applied settings. If the Envoy does not return a
+        complete schedule document, the stored data is left at the last
+        known state rather than at an optimistic one and
+        EnvoyCommunicationError is raised. The update was sent in that
+        case, use :any:`Envoy.update` to establish the actual state.
+
+        Specify refresh to re-read the schedule from the Envoy right
+        before the settings are merged into it. Use this when the
+        Enphase cloud or app may have changed settings since the last
+        data collection, to avoid sending values from stale data.
 
         :param new_data: dict of settings to change
+        :param refresh: re-read the schedule from the Envoy before
+            merging the settings to change into it
         :raises EnvoyFeatureNotAvailable: If GENERATOR feature is not available in Envoy
         :raises EnvoyFeatureNotAvailable: If this firmware does not expose the gen_schedule endpoint
         :raises ValueError: If update was attempted before first data was requested from Envoy
         :raises ValueError: If an unknown setting is specified or a value is out of range
+        :raises ValueError: If the resulting default_start_soc is not lower than default_stop_soc
         :raises EnvoyCommunicationError: when aiohttp network or communication error occurs.
+        :raises EnvoyCommunicationError: If the Envoy does not return a complete schedule document
         :raises EnvoyHTTPStatusError: when HTTP status is not 2xx.
         :return: generator schedule JSON returned by Envoy
         """
@@ -1154,21 +1169,68 @@ class Envoy:
             raise EnvoyFeatureNotAvailable(
                 "The generator schedule endpoint is not available on this Envoy."
             )
-        new_data = self._validated_generator_schedule(new_data)
+        if refresh:
+            # re-read before merging so settings changed by the Enphase
+            # cloud or app since the last data collection are not echoed
+            # back with stale values
+            current = await self._json_request(URL_GEN_SCHEDULE, None)
+            data.generator_schedule = self._model_from_document(
+                URL_GEN_SCHEDULE,
+                current,
+                EnvoyGeneratorSchedule.from_api,
+                "The Envoy returned an incomplete generator schedule, "
+                "no data was changed and no update was sent",
+            )
+            data.raw[URL_GEN_SCHEDULE] = current
+        new_data = self._validated_generator_schedule(new_data, data.generator_schedule)
         # merge with the current settings and send the whole document
         new_model = replace(data.generator_schedule, **new_data)
         result = await self._json_request(URL_GEN_SCHEDULE, new_model.to_api())
         # The Envoy returns the resulting schedule, use it to keep the
-        # raw and the typed data consistent until the next data update
-        if isinstance(result, dict) and "exercise_config" in result:
-            data.raw[URL_GEN_SCHEDULE] = result
-            data.generator_schedule = EnvoyGeneratorSchedule.from_api(result)
-        else:
-            data.raw[URL_GEN_SCHEDULE] = new_model.to_api()
-            data.generator_schedule = new_model
+        # raw and the typed data consistent until the next data update.
+        # Build the model first: if the reply is not a complete document
+        # the stored data is left at the last known state rather than at
+        # an optimistic one the Envoy never confirmed.
+        new_state = self._model_from_document(
+            URL_GEN_SCHEDULE,
+            result,
+            EnvoyGeneratorSchedule.from_api,
+            "The Envoy returned an incomplete generator schedule for the update, "
+            "the update was sent but the stored data was left unchanged",
+        )
+        data.raw[URL_GEN_SCHEDULE] = result
+        data.generator_schedule = new_state
         return result
 
-    def _validated_generator_schedule(self, new_data: dict[str, Any]) -> dict[str, Any]:
+    def _model_from_document(
+        self,
+        end_point: str,
+        document: Any,
+        from_api: Callable[[Any], _ModelT],
+        message: str,
+    ) -> _ModelT:
+        """
+        Build a data model from a document returned by the Envoy.
+
+        Used to verify a document returned for a write action is complete
+        before any stored data is replaced with it.
+
+        :param end_point: Envoy endpoint the document came from
+        :param document: JSON document returned by the Envoy
+        :param from_api: model method to build the model from the document
+        :param message: message to report if the document is incomplete
+        :raises EnvoyCommunicationError: If the document is not a complete document
+        :return: data model built from the document
+        """
+        try:
+            return from_api(document)
+        except (KeyError, TypeError, IndexError) as err:
+            _LOGGER.debug("Incomplete document returned by %s: %s", end_point, document)
+            raise EnvoyCommunicationError(f"{message}: {end_point} {err!s}") from err
+
+    def _validated_generator_schedule(
+        self, new_data: dict[str, Any], current: EnvoyGeneratorSchedule
+    ) -> dict[str, Any]:
         """
         Validate generator schedule settings to change.
 
@@ -1212,10 +1274,19 @@ class Envoy:
         for soc_key in ("default_start_soc", "default_stop_soc"):
             if (soc := validated.get(soc_key)) is not None and not 0 <= soc <= 100:
                 raise ValueError(f"{soc_key} must be between 0 and 100")
+        # the generator starts at the low SOC and stops at the high one,
+        # verify the resulting pair against the settings not being changed
+        start_soc = validated.get("default_start_soc", current.default_start_soc)
+        stop_soc = validated.get("default_stop_soc", current.default_stop_soc)
+        if start_soc >= stop_soc:
+            raise ValueError(
+                f"default_start_soc ({start_soc}) must be lower than "
+                f"default_stop_soc ({stop_soc})"
+            )
         return validated
 
     async def set_generator_charge_from_generator(
-        self, charge_from_generator: bool
+        self, charge_from_generator: bool, refresh: bool = False
     ) -> dict[str, Any]:
         """
         Enable or disable battery charging from the standby generator.
@@ -1235,14 +1306,28 @@ class Envoy:
         verify the applied setting. This matters here: on systems
         without Enphase batteries the Envoy accepts the request with
         HTTP 200 but normalizes charge_from_generator back to true,
-        verified live on firmware D8.3.5169.
+        verified live on firmware D8.3.5169. If the Envoy does not
+        return a complete configuration document, the stored data is
+        left at the last known state rather than at an optimistic one
+        and EnvoyCommunicationError is raised. The update was sent in
+        that case, use :any:`Envoy.update` to establish the actual
+        state.
+
+        Specify refresh to re-read the configuration from the Envoy
+        right before the setting is changed in it. Use this when the
+        Enphase cloud or app may have changed the configuration since
+        the last data collection, to avoid sending values from stale
+        data.
 
         :param charge_from_generator: True to allow charging batteries
             from the generator, False to disallow
+        :param refresh: re-read the configuration from the Envoy before
+            changing the setting in it
         :raises EnvoyFeatureNotAvailable: If GENERATOR feature is not available in Envoy
         :raises TypeError: If charge_from_generator is not of type bool
         :raises ValueError: If update was attempted before first data was requested from Envoy
         :raises EnvoyCommunicationError: when aiohttp network or communication error occurs.
+        :raises EnvoyCommunicationError: If the Envoy does not return a complete configuration document
         :raises EnvoyHTTPStatusError: when HTTP status is not 2xx.
         :return: generator configuration JSON returned by Envoy
         """
@@ -1256,6 +1341,19 @@ class Envoy:
             raise ValueError(
                 "Tried to set charge from generator before the Envoy was queried."
             )
+        if refresh:
+            # re-read before merging so configuration changed by the
+            # Enphase cloud or app since the last data collection is not
+            # echoed back with stale values
+            current = await self._json_request(URL_GEN_CONFIG, None)
+            data.generator_config = self._model_from_document(
+                URL_GEN_CONFIG,
+                current,
+                EnvoyGeneratorConfig.from_api,
+                "The Envoy returned an incomplete generator configuration, "
+                "no data was changed and no update was sent",
+            )
+            data.raw[URL_GEN_CONFIG] = current
         # gen_config is the GENERATOR detection gate, so it is always
         # collected during update when the feature is available
         if TYPE_CHECKING:
@@ -1265,13 +1363,19 @@ class Envoy:
         )
         result = await self._json_request(URL_GEN_CONFIG, new_model.to_api())
         # The Envoy returns the resulting configuration, use it to keep
-        # the raw and the typed data consistent until the next update
-        if isinstance(result, dict) and "charge_from_generator" in result:
-            data.raw[URL_GEN_CONFIG] = result
-            data.generator_config = EnvoyGeneratorConfig.from_api(result)
-        else:
-            data.raw[URL_GEN_CONFIG] = new_model.to_api()
-            data.generator_config = new_model
+        # the raw and the typed data consistent until the next update.
+        # Build the model first: if the reply is not a complete document
+        # the stored data is left at the last known state rather than at
+        # an optimistic one the Envoy never confirmed.
+        new_state = self._model_from_document(
+            URL_GEN_CONFIG,
+            result,
+            EnvoyGeneratorConfig.from_api,
+            "The Envoy returned an incomplete generator configuration for the update, "
+            "the update was sent but the stored data was left unchanged",
+        )
+        data.raw[URL_GEN_CONFIG] = result
+        data.generator_config = new_state
         return result
 
     async def set_acb_sleep(self, configs: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -1113,7 +1113,9 @@ class Envoy:
             the sibling /ivp/ss/ write endpoints (gen_mode,
             dry_contact_settings).
 
-        :param freq_in_weeks: exercise interval in weeks, 1 or greater
+        :param freq_in_weeks: exercise interval in weeks, 1-4, matching
+            the official Enphase app's every-1-4-weeks domain (vendor UI
+            domain; firmware behavior for larger values untested)
         :param day: day of the week the exercise runs on,
             short day name "Mon" through "Sun", any case
         :param start: exercise start time in minutes after
@@ -1136,8 +1138,8 @@ class Envoy:
             raise EnvoyFeatureNotAvailable(
                 "This feature is not available on this Envoy."
             )
-        if freq_in_weeks < 1:
-            raise ValueError("freq_in_weeks must be 1 or greater")
+        if not 1 <= freq_in_weeks <= 4:
+            raise ValueError("freq_in_weeks must be between 1 and 4 weeks")
         exercise_day = day.capitalize()
         if exercise_day not in GENERATOR_EXERCISE_DAYS:
             raise ValueError(

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from copy import deepcopy
 from dataclasses import replace
 from functools import cached_property, partial
 from http import HTTPStatus
@@ -39,6 +38,7 @@ from .const import (
     ENDPOINT_URL_HOME,
     GENERATOR_EXERCISE_DAYS,
     GENERATOR_MODES,
+    GENERATOR_SCHEDULE_SETTINGS,
     LOCAL_TIMEOUT,
     MAX_PROBE_REQUEST_ATTEMPTS,
     MAX_PROBE_REQUEST_DELAY,
@@ -65,6 +65,7 @@ from .firmware import EnvoyFirmware
 from .json import json_loads
 from .models.common import CommonProperties
 from .models.envoy import EnvoyData
+from .models.generator import EnvoyGeneratorConfig, EnvoyGeneratorSchedule
 from .models.meters import CtType, EnvoyPhaseMode
 from .models.tariff import EnvoyStorageMode
 from .ssl import NO_VERIFY_SSL_CONTEXT
@@ -1083,106 +1084,135 @@ class Envoy:
             self.data.generator_mode.gen_cmd = gen_cmd
         return result
 
-    async def set_generator_exercise_schedule(
-        self,
-        *,
-        freq_in_weeks: int,
-        day: str,
-        start: int,
-        duration: int,
+    async def update_generator_schedule(
+        self, new_data: dict[str, Any]
     ) -> dict[str, Any]:
         """
-        Set the standby generator exercise schedule.
+        Update the standby generator schedule settings.
 
-        POST the gen_schedule data as last read from the Envoy to
-        /ivp/ss/gen_schedule with the exercise_config fields
-        (freq_in_weeks, day, start, duration) replaced by the specified
-        values. All other blocks of the schedule data (default_soc,
-        schedule) are sent back unchanged, as partial updates may not be
-        supported. The day input is case-insensitive and normalized to
-        the capitalized short day name the firmware reports (e.g. "Thu").
-        Requires a system with an Enpower and standby generator
-        installed. Upon successful POST, update the exercise schedule in
-        internal data as the Envoy needs some time to implement the
-        change and have status updated.
+        POST updated generator schedule settings to /ivp/ss/gen_schedule
+        in the Envoy. New_data dict can contain one or more of below
+        items to set. Only include key/values to change.
 
-        .. note::
-            The POST body shape round-trips the GET response shape and
-            was verified live on firmware D8.3.5169 (2026-07-30): writes
-            are accepted, persisted at the controller and synced to
-            Enlighten. POST matches the sibling /ivp/ss/ write endpoints
-            (gen_mode, dry_contact_settings). Writing the schedule also
-            (re)applies the echoed default_soc block as the ACTIVE
-            generator start/stop SOC settings — relevant on systems with
-            Enphase batteries.
+        .. code-block:: json
 
-        :param freq_in_weeks: exercise interval in weeks, 1-4, matching
-            the official Enphase app's every-1-4-weeks domain (vendor UI
-            domain; firmware behavior for larger values untested)
-        :param day: day of the week the exercise runs on,
-            short day name "Mon" through "Sun", any case
-        :param start: exercise start time in minutes after
-            midnight (0-1439)
-        :param duration: exercise duration in minutes, 10-60 in steps
-            of 10, matching the official Enphase app. Firmware accepts
-            and persists intermediate values (25 verified live on
-            D8.3.5169) but the Enlighten UI renders them as a blank
-            duration field, so the library enforces the vendor domain
-            to avoid writing values the official app cannot display.
+            {
+                "exercise_freq_in_weeks": 1,
+                "exercise_day": "Mon",
+                "exercise_start": 840,
+                "exercise_duration": 20,
+                "default_start_soc": 30,
+                "default_stop_soc": 70,
+            },
+
+        Settings specified in the data dict are updated in the
+        internally stored generator_schedule and send as a whole to
+        update the Envoy, as partial updates are not supported by the
+        endpoint. The exercise_day value is case insensitive and
+        normalized to the capitalized short day name the firmware
+        reports, e.g. "Thu".
+
+        Value domains match the official Enphase app: exercise_day
+        "Mon" through "Sun", exercise_start 0-1439 minutes after
+        midnight, exercise_duration 10-60 minutes in steps of 10,
+        exercise_freq_in_weeks 1-4 and the SOC values 0-100. Firmware
+        accepts and persists out-of-domain durations, but the Enlighten
+        UI can not display them, so the vendor domain is enforced.
+
+        The default_start_soc and default_stop_soc are applied by the
+        firmware as the active generator start/stop SOC, as reported in
+        /ivp/ensemble/generator. They are always sent, so a schedule
+        update also (re)applies the SOC values held in
+        :any:`EnvoyData.generator_schedule` at the time of the call.
+        On systems with Enphase batteries, call :any:`Envoy.update`
+        first if another application may have changed them since the
+        last data collection.
+
+        The Envoy returns the resulting generator schedule, which is
+        used to update :any:`EnvoyData.generator_schedule` and the raw
+        data. Callers can use the returned data or the updated model to
+        verify the applied settings.
+
+        :param new_data: dict of settings to change
         :raises EnvoyFeatureNotAvailable: If GENERATOR feature is not available in Envoy
         :raises EnvoyFeatureNotAvailable: If this firmware does not expose the gen_schedule endpoint
         :raises ValueError: If update was attempted before first data was requested from Envoy
-        :raises ValueError: If freq_in_weeks, day, start or duration is out of range
+        :raises ValueError: If an unknown setting is specified or a value is out of range
         :raises EnvoyCommunicationError: when aiohttp network or communication error occurs.
         :raises EnvoyHTTPStatusError: when HTTP status is not 2xx.
-        :return: JSON returned by Envoy
+        :return: generator schedule JSON returned by Envoy
         """
         if not self.supported_features & SupportedFeatures.GENERATOR:
             raise EnvoyFeatureNotAvailable(
                 "This feature is not available on this Envoy."
             )
-        if not 1 <= freq_in_weeks <= 4:
-            raise ValueError("freq_in_weeks must be between 1 and 4 weeks")
-        exercise_day = day.capitalize()
-        if exercise_day not in GENERATOR_EXERCISE_DAYS:
-            raise ValueError(
-                f"Invalid exercise day: {day}. "
-                f"Valid days: {', '.join(GENERATOR_EXERCISE_DAYS)}"
-            )
-        if not 0 <= start <= 1439:
-            raise ValueError("start must be between 0 and 1439 minutes after midnight")
-        if not 10 <= duration <= 60 or duration % 10 != 0:
-            raise ValueError(
-                "duration must be between 10 and 60 minutes in steps of 10"
-            )
         if not (data := self.data):
             raise ValueError(
-                "Tried to set generator exercise schedule before the Envoy was queried."
+                "Tried to set generator schedule before the Envoy was queried."
             )
-        if (current_schedule := data.raw.get(URL_GEN_SCHEDULE)) is None:
+        if data.generator_schedule is None:
             raise EnvoyFeatureNotAvailable(
                 "The generator schedule endpoint is not available on this Envoy."
             )
-        new_schedule: dict[str, Any] = deepcopy(current_schedule)
-        new_schedule["exercise_config"] = {
-            **new_schedule["exercise_config"],
-            "freq_in_weeks": freq_in_weeks,
-            "day": exercise_day,
-            "start": start,
-            "duration": duration,
-        }
-        result = await self._json_request(URL_GEN_SCHEDULE, new_schedule)
-        # The Envoy takes a few seconds before it will reflect the new
-        # schedule so we preemptively update it. When raw gen_schedule
-        # data is present the model was populated from it in the same
-        # update cycle.
-        if TYPE_CHECKING:
-            assert data.generator_schedule is not None  # nosec
-        data.generator_schedule.exercise_freq_in_weeks = freq_in_weeks
-        data.generator_schedule.exercise_day = exercise_day
-        data.generator_schedule.exercise_start = start
-        data.generator_schedule.exercise_duration = duration
+        new_data = self._validated_generator_schedule(new_data)
+        # merge with the current settings and send the whole document
+        new_model = replace(data.generator_schedule, **new_data)
+        result = await self._json_request(URL_GEN_SCHEDULE, new_model.to_api())
+        # The Envoy returns the resulting schedule, use it to keep the
+        # raw and the typed data consistent until the next data update
+        if isinstance(result, dict) and "exercise_config" in result:
+            data.raw[URL_GEN_SCHEDULE] = result
+            data.generator_schedule = EnvoyGeneratorSchedule.from_api(result)
+        else:
+            data.raw[URL_GEN_SCHEDULE] = new_model.to_api()
+            data.generator_schedule = new_model
         return result
+
+    def _validated_generator_schedule(self, new_data: dict[str, Any]) -> dict[str, Any]:
+        """
+        Validate generator schedule settings to change.
+
+        Only settings present in the data dict are validated, values
+        are returned normalized where applicable.
+
+        :param new_data: dict of settings to change
+        :raises ValueError: If an unknown setting is specified or a value is out of range
+        :return: validated and normalized settings to change
+        """
+        if unknown := set(new_data) - GENERATOR_SCHEDULE_SETTINGS:
+            raise ValueError(
+                f"Unknown generator schedule setting(s): {', '.join(sorted(unknown))}. "
+                f"Valid settings: {', '.join(sorted(GENERATOR_SCHEDULE_SETTINGS))}"
+            )
+        validated = dict(new_data)
+        if (freq := validated.get("exercise_freq_in_weeks")) is not None and (
+            not 1 <= freq <= 4
+        ):
+            raise ValueError("exercise_freq_in_weeks must be between 1 and 4 weeks")
+        if (day := validated.get("exercise_day")) is not None:
+            exercise_day = str(day).capitalize()
+            if exercise_day not in GENERATOR_EXERCISE_DAYS:
+                raise ValueError(
+                    f"Invalid exercise day: {day}. "
+                    f"Valid days: {', '.join(GENERATOR_EXERCISE_DAYS)}"
+                )
+            validated["exercise_day"] = exercise_day
+        if (start := validated.get("exercise_start")) is not None and (
+            not 0 <= start <= 1439
+        ):
+            raise ValueError(
+                "exercise_start must be between 0 and 1439 minutes after midnight"
+            )
+        if (duration := validated.get("exercise_duration")) is not None and (
+            not 10 <= duration <= 60 or duration % 10 != 0
+        ):
+            raise ValueError(
+                "exercise_duration must be between 10 and 60 minutes in steps of 10"
+            )
+        for soc_key in ("default_start_soc", "default_stop_soc"):
+            if (soc := validated.get(soc_key)) is not None and not 0 <= soc <= 100:
+                raise ValueError(f"{soc_key} must be between 0 and 100")
+        return validated
 
     async def set_generator_charge_from_generator(
         self, charge_from_generator: bool
@@ -1190,27 +1220,22 @@ class Envoy:
         """
         Enable or disable battery charging from the standby generator.
 
-        POST the gen_config data as last read from the Envoy to
-        /ivp/ss/gen_config with only charge_from_generator replaced by
-        the specified value, as partial updates may not be supported.
-        Other gen_config fields (name plate rating, max continuous amps,
-        generator type/model/manufacturer, start method) are
-        installer-grade settings and are intentionally not settable
-        through this library. Requires a system with an Enpower and
-        standby generator installed. Upon successful POST, update the
-        charge from generator setting in internal data as the Envoy
-        needs some time to implement the change and have status updated.
+        POST the generator configuration with only charge_from_generator
+        changed to /ivp/ss/gen_config. The configuration is sent as a
+        whole, built from :any:`EnvoyData.generator_config`, as partial
+        updates are not supported by the endpoint. Other gen_config
+        fields (name plate rating, max continuous amps, generator
+        type/model/manufacturer, start method) are installer-grade
+        settings and are intentionally not settable through this
+        library.
 
-        .. note::
-            The POST body shape round-trips the GET response shape and
-            matches the sibling /ivp/ss/ write endpoints (gen_mode,
-            dry_contact_settings). Verified live on firmware D8.3.5169
-            (2026-07-30): on systems without Enphase batteries the
-            firmware accepts the write (HTTP 200) but silently
-            normalizes charge_from_generator back to true. The response
-            body echoes the resulting EFFECTIVE configuration, so
-            callers can compare response to request to detect an
-            accepted-but-ignored write.
+        The Envoy returns the resulting generator configuration, which
+        is used to update :any:`EnvoyData.generator_config` and the raw
+        data. Callers can use the returned data or the updated model to
+        verify the applied setting. This matters here: on systems
+        without Enphase batteries the Envoy accepts the request with
+        HTTP 200 but normalizes charge_from_generator back to true,
+        verified live on firmware D8.3.5169.
 
         :param charge_from_generator: True to allow charging batteries
             from the generator, False to disallow
@@ -1219,7 +1244,7 @@ class Envoy:
         :raises ValueError: If update was attempted before first data was requested from Envoy
         :raises EnvoyCommunicationError: when aiohttp network or communication error occurs.
         :raises EnvoyHTTPStatusError: when HTTP status is not 2xx.
-        :return: JSON returned by Envoy
+        :return: generator configuration JSON returned by Envoy
         """
         if not self.supported_features & SupportedFeatures.GENERATOR:
             raise EnvoyFeatureNotAvailable(
@@ -1231,16 +1256,22 @@ class Envoy:
             raise ValueError(
                 "Tried to set charge from generator before the Envoy was queried."
             )
-        # gen_config is the GENERATOR detection gate and is always
-        # fetched during update, so raw data and model are present here
-        new_config: dict[str, Any] = deepcopy(data.raw[URL_GEN_CONFIG])
-        new_config["charge_from_generator"] = charge_from_generator
-        result = await self._json_request(URL_GEN_CONFIG, new_config)
-        # The Envoy takes a few seconds before it will reflect the new
-        # setting so we preemptively update it
+        # gen_config is the GENERATOR detection gate, so it is always
+        # collected during update when the feature is available
         if TYPE_CHECKING:
             assert data.generator_config is not None  # nosec
-        data.generator_config.charge_from_generator = charge_from_generator
+        new_model = replace(
+            data.generator_config, charge_from_generator=charge_from_generator
+        )
+        result = await self._json_request(URL_GEN_CONFIG, new_model.to_api())
+        # The Envoy returns the resulting configuration, use it to keep
+        # the raw and the typed data consistent until the next update
+        if isinstance(result, dict) and "charge_from_generator" in result:
+            data.raw[URL_GEN_CONFIG] = result
+            data.generator_config = EnvoyGeneratorConfig.from_api(result)
+        else:
+            data.raw[URL_GEN_CONFIG] = new_model.to_api()
+            data.generator_config = new_model
         return result
 
     async def set_acb_sleep(self, configs: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable
+from copy import deepcopy
 from dataclasses import replace
 from functools import cached_property, partial
 from http import HTTPStatus
@@ -36,6 +37,7 @@ from .const import (
     DEFAULT_MAX_REQUEST_ATTEMPTS,
     DEFAULT_MAX_REQUEST_DELAY,
     ENDPOINT_URL_HOME,
+    GENERATOR_EXERCISE_DAYS,
     GENERATOR_MODES,
     LOCAL_TIMEOUT,
     MAX_PROBE_REQUEST_ATTEMPTS,
@@ -43,7 +45,9 @@ from .const import (
     URL_ACB_CONFIG,
     URL_DRY_CONTACT_SETTINGS,
     URL_DRY_CONTACT_STATUS,
+    URL_GEN_CONFIG,
     URL_GEN_MODE,
+    URL_GEN_SCHEDULE,
     URL_GRID_RELAY,
     URL_TARIFF,
     SupportedFeatures,
@@ -1077,6 +1081,150 @@ class Envoy:
         # so we preemptively update it
         if self.data and self.data.generator_mode:
             self.data.generator_mode.gen_cmd = gen_cmd
+        return result
+
+    async def set_generator_exercise_schedule(
+        self,
+        *,
+        freq_in_weeks: int,
+        day: str,
+        start: int,
+        duration: int,
+    ) -> dict[str, Any]:
+        """
+        Set the standby generator exercise schedule.
+
+        POST the gen_schedule data as last read from the Envoy to
+        /ivp/ss/gen_schedule with the exercise_config fields
+        (freq_in_weeks, day, start, duration) replaced by the specified
+        values. All other blocks of the schedule data (default_soc,
+        schedule) are sent back unchanged, as partial updates may not be
+        supported. The day input is case-insensitive and normalized to
+        the capitalized short day name the firmware reports (e.g. "Thu").
+        Requires a system with an Enpower and standby generator
+        installed. Upon successful POST, update the exercise schedule in
+        internal data as the Envoy needs some time to implement the
+        change and have status updated.
+
+        .. note::
+            The request body shape is derived from the GET response shape
+            observed on live firmware (D8.2.127 and D8.3.5169) and has
+            not yet been verified against hardware. POST is used to match
+            the sibling /ivp/ss/ write endpoints (gen_mode,
+            dry_contact_settings).
+
+        :param freq_in_weeks: exercise interval in weeks, 1 or greater
+        :param day: day of the week the exercise runs on,
+            short day name "Mon" through "Sun", any case
+        :param start: exercise start time in minutes after
+            midnight (0-1439)
+        :param duration: exercise duration in minutes, 1 or greater
+        :raises EnvoyFeatureNotAvailable: If GENERATOR feature is not available in Envoy
+        :raises EnvoyFeatureNotAvailable: If this firmware does not expose the gen_schedule endpoint
+        :raises ValueError: If update was attempted before first data was requested from Envoy
+        :raises ValueError: If freq_in_weeks, day, start or duration is out of range
+        :raises EnvoyCommunicationError: when aiohttp network or communication error occurs.
+        :raises EnvoyHTTPStatusError: when HTTP status is not 2xx.
+        :return: JSON returned by Envoy
+        """
+        if not self.supported_features & SupportedFeatures.GENERATOR:
+            raise EnvoyFeatureNotAvailable(
+                "This feature is not available on this Envoy."
+            )
+        if freq_in_weeks < 1:
+            raise ValueError("freq_in_weeks must be 1 or greater")
+        exercise_day = day.capitalize()
+        if exercise_day not in GENERATOR_EXERCISE_DAYS:
+            raise ValueError(
+                f"Invalid exercise day: {day}. "
+                f"Valid days: {', '.join(GENERATOR_EXERCISE_DAYS)}"
+            )
+        if not 0 <= start <= 1439:
+            raise ValueError("start must be between 0 and 1439 minutes after midnight")
+        if duration < 1:
+            raise ValueError("duration must be 1 or greater")
+        if not (data := self.data):
+            raise ValueError(
+                "Tried to set generator exercise schedule before the Envoy was queried."
+            )
+        if (current_schedule := data.raw.get(URL_GEN_SCHEDULE)) is None:
+            raise EnvoyFeatureNotAvailable(
+                "The generator schedule endpoint is not available on this Envoy."
+            )
+        new_schedule: dict[str, Any] = deepcopy(current_schedule)
+        new_schedule["exercise_config"] = {
+            **new_schedule["exercise_config"],
+            "freq_in_weeks": freq_in_weeks,
+            "day": exercise_day,
+            "start": start,
+            "duration": duration,
+        }
+        result = await self._json_request(URL_GEN_SCHEDULE, new_schedule)
+        # The Envoy takes a few seconds before it will reflect the new
+        # schedule so we preemptively update it. When raw gen_schedule
+        # data is present the model was populated from it in the same
+        # update cycle.
+        if TYPE_CHECKING:
+            assert data.generator_schedule is not None  # nosec
+        data.generator_schedule.exercise_freq_in_weeks = freq_in_weeks
+        data.generator_schedule.exercise_day = exercise_day
+        data.generator_schedule.exercise_start = start
+        data.generator_schedule.exercise_duration = duration
+        return result
+
+    async def set_generator_charge_from_generator(
+        self, charge_from_generator: bool
+    ) -> dict[str, Any]:
+        """
+        Enable or disable battery charging from the standby generator.
+
+        POST the gen_config data as last read from the Envoy to
+        /ivp/ss/gen_config with only charge_from_generator replaced by
+        the specified value, as partial updates may not be supported.
+        Other gen_config fields (name plate rating, max continuous amps,
+        generator type/model/manufacturer, start method) are
+        installer-grade settings and are intentionally not settable
+        through this library. Requires a system with an Enpower and
+        standby generator installed. Upon successful POST, update the
+        charge from generator setting in internal data as the Envoy
+        needs some time to implement the change and have status updated.
+
+        .. note::
+            The request body shape is derived from the GET response shape
+            observed on live firmware (D8.2.127 and D8.3.5169) and has
+            not yet been verified against hardware. POST is used to match
+            the sibling /ivp/ss/ write endpoints (gen_mode,
+            dry_contact_settings).
+
+        :param charge_from_generator: True to allow charging batteries
+            from the generator, False to disallow
+        :raises EnvoyFeatureNotAvailable: If GENERATOR feature is not available in Envoy
+        :raises TypeError: If charge_from_generator is not of type bool
+        :raises ValueError: If update was attempted before first data was requested from Envoy
+        :raises EnvoyCommunicationError: when aiohttp network or communication error occurs.
+        :raises EnvoyHTTPStatusError: when HTTP status is not 2xx.
+        :return: JSON returned by Envoy
+        """
+        if not self.supported_features & SupportedFeatures.GENERATOR:
+            raise EnvoyFeatureNotAvailable(
+                "This feature is not available on this Envoy."
+            )
+        if type(charge_from_generator) is not bool:
+            raise TypeError("charge_from_generator must be of type bool")
+        if not (data := self.data):
+            raise ValueError(
+                "Tried to set charge from generator before the Envoy was queried."
+            )
+        # gen_config is the GENERATOR detection gate and is always
+        # fetched during update, so raw data and model are present here
+        new_config: dict[str, Any] = deepcopy(data.raw[URL_GEN_CONFIG])
+        new_config["charge_from_generator"] = charge_from_generator
+        result = await self._json_request(URL_GEN_CONFIG, new_config)
+        # The Envoy takes a few seconds before it will reflect the new
+        # setting so we preemptively update it
+        if TYPE_CHECKING:
+            assert data.generator_config is not None  # nosec
+        data.generator_config.charge_from_generator = charge_from_generator
         return result
 
     async def set_acb_sleep(self, configs: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/pyenphase/models/generator.py
+++ b/src/pyenphase/models/generator.py
@@ -98,6 +98,24 @@ class EnvoyGeneratorConfig:
             charge_from_generator=config["charge_from_generator"],
         )
 
+    def to_api(self) -> dict[str, Any]:
+        """Convert to API format."""
+        return {
+            "max_cont_gen_amps": self.max_cont_gen_amps,
+            "min_gen_loading_perc": self.min_gen_loading_perc,
+            "max_gen_efficiency_perc": self.max_gen_efficiency_perc,
+            "name_plate_rating_wat": self.name_plate_rating_wat,
+            "start_method": self.start_method,
+            "warm_up_mins": self.warm_up_mins,
+            "cool_down_mins": self.cool_down_mins,
+            "gen_type": self.gen_type,
+            "model": self.model,
+            "manufacturer": self.manufacturer,
+            "last_updated_by": self.last_updated_by,
+            "generator_id": self.generator_id,
+            "charge_from_generator": self.charge_from_generator,
+        }
+
 
 @dataclass(slots=True)
 class EnvoyGeneratorMode:
@@ -128,9 +146,14 @@ class EnvoyGeneratorSchedule:
     exercise_duration: int
     #: Day of the week the exercise runs on
     exercise_day: str
+    #: Battery state of charge at which the generator starts by default
     default_start_soc: int
+    #: Battery state of charge at which the generator stops by default
     default_stop_soc: int
+    #: Source of the last schedule update
     last_updated_by: str
+    #: Generator operation schedule, passed through unmodified
+    schedule: dict[str, Any]
 
     @classmethod
     def from_api(cls, schedule: dict[str, Any]) -> EnvoyGeneratorSchedule:
@@ -145,4 +168,22 @@ class EnvoyGeneratorSchedule:
             default_start_soc=default_soc["start_soc"],
             default_stop_soc=default_soc["stop_soc"],
             last_updated_by=schedule["last_updated_by"],
+            schedule=schedule["schedule"],
         )
+
+    def to_api(self) -> dict[str, Any]:
+        """Convert to API format."""
+        return {
+            "exercise_config": {
+                "freq_in_weeks": self.exercise_freq_in_weeks,
+                "start": self.exercise_start,
+                "duration": self.exercise_duration,
+                "day": self.exercise_day,
+            },
+            "default_soc": {
+                "start_soc": self.default_start_soc,
+                "stop_soc": self.default_stop_soc,
+            },
+            "schedule": self.schedule,
+            "last_updated_by": self.last_updated_by,
+        }

--- a/src/pyenphase/updaters/generator.py
+++ b/src/pyenphase/updaters/generator.py
@@ -33,7 +33,12 @@ class EnvoyGeneratorUpdater(EnvoyUpdater):
     _gen_mode_available: bool = False
 
     async def _optional_endpoint_available(self, end_point: str) -> bool:
-        """Probe an optional generator endpoint and report its availability."""
+        """
+        Probe an optional generator endpoint and report its availability.
+
+        :param end_point: Envoy endpoint to probe
+        :return: True if the endpoint returned usable data
+        """
         try:
             result = await self._json_probe_request(end_point)
         except ENDPOINT_PROBE_EXCEPTIONS as e:

--- a/tests/__snapshots__/test_acb.ambr
+++ b/tests/__snapshots__/test_acb.ambr
@@ -14926,6 +14926,31 @@
       'exercise_freq_in_weeks': 1,
       'exercise_start': 750,
       'last_updated_by': 'ITK',
+      'schedule': dict({
+        'default': list([
+          dict({
+            'days': list([
+              dict({
+                'id': 'all_days',
+                'periods': list([
+                  dict({
+                    'duration': 1440.0,
+                    'id': 'normal_1',
+                    'setting': 'AON',
+                    'start': 0.0,
+                    'start_soc': 100.0,
+                    'stop_soc': -1.0,
+                  }),
+                ]),
+                'week_days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+              }),
+            ]),
+            'end': '12/31',
+            'id': 'always_on',
+            'start': '1/1',
+          }),
+        ]),
+      }),
     }),
     'inverters': dict({
       '482218039091': dict({

--- a/tests/__snapshots__/test_ct_meters.ambr
+++ b/tests/__snapshots__/test_ct_meters.ambr
@@ -10297,6 +10297,31 @@
       'exercise_freq_in_weeks': 1,
       'exercise_start': 750,
       'last_updated_by': 'ITK',
+      'schedule': dict({
+        'default': list([
+          dict({
+            'days': list([
+              dict({
+                'id': 'all_days',
+                'periods': list([
+                  dict({
+                    'duration': 1440.0,
+                    'id': 'normal_1',
+                    'setting': 'AON',
+                    'start': 0.0,
+                    'start_soc': 100.0,
+                    'stop_soc': -1.0,
+                  }),
+                ]),
+                'week_days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+              }),
+            ]),
+            'end': '12/31',
+            'id': 'always_on',
+            'start': '1/1',
+          }),
+        ]),
+      }),
     }),
     'inverters': dict({
       '482218039091': dict({

--- a/tests/__snapshots__/test_endpoints.ambr
+++ b/tests/__snapshots__/test_endpoints.ambr
@@ -18494,6 +18494,31 @@
       'exercise_freq_in_weeks': 1,
       'exercise_start': 750,
       'last_updated_by': 'ITK',
+      'schedule': dict({
+        'default': list([
+          dict({
+            'days': list([
+              dict({
+                'id': 'all_days',
+                'periods': list([
+                  dict({
+                    'duration': 1440.0,
+                    'id': 'normal_1',
+                    'setting': 'AON',
+                    'start': 0.0,
+                    'start_soc': 100.0,
+                    'stop_soc': -1.0,
+                  }),
+                ]),
+                'week_days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+              }),
+            ]),
+            'end': '12/31',
+            'id': 'always_on',
+            'start': '1/1',
+          }),
+        ]),
+      }),
     }),
     'inverters': dict({
       '482218039091': dict({

--- a/tests/__snapshots__/test_ensemble.ambr
+++ b/tests/__snapshots__/test_ensemble.ambr
@@ -18494,6 +18494,31 @@
       'exercise_freq_in_weeks': 1,
       'exercise_start': 750,
       'last_updated_by': 'ITK',
+      'schedule': dict({
+        'default': list([
+          dict({
+            'days': list([
+              dict({
+                'id': 'all_days',
+                'periods': list([
+                  dict({
+                    'duration': 1440.0,
+                    'id': 'normal_1',
+                    'setting': 'AON',
+                    'start': 0.0,
+                    'start_soc': 100.0,
+                    'stop_soc': -1.0,
+                  }),
+                ]),
+                'week_days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+              }),
+            ]),
+            'end': '12/31',
+            'id': 'always_on',
+            'start': '1/1',
+          }),
+        ]),
+      }),
     }),
     'inverters': dict({
       '482218039091': dict({
@@ -27851,6 +27876,31 @@
       'exercise_freq_in_weeks': 3,
       'exercise_start': 945,
       'last_updated_by': 'ITK',
+      'schedule': dict({
+        'default': list([
+          dict({
+            'days': list([
+              dict({
+                'id': 'all_days',
+                'periods': list([
+                  dict({
+                    'duration': 1440.0,
+                    'id': 'normal_1',
+                    'setting': 'AON',
+                    'start': 0.0,
+                    'start_soc': 100.0,
+                    'stop_soc': -1.0,
+                  }),
+                ]),
+                'week_days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+              }),
+            ]),
+            'end': '12/31',
+            'id': 'always_on',
+            'start': '1/1',
+          }),
+        ]),
+      }),
     }),
     'inverters': dict({
       '482208990001': dict({

--- a/tests/__snapshots__/test_net_consumption.ambr
+++ b/tests/__snapshots__/test_net_consumption.ambr
@@ -18494,6 +18494,31 @@
       'exercise_freq_in_weeks': 1,
       'exercise_start': 750,
       'last_updated_by': 'ITK',
+      'schedule': dict({
+        'default': list([
+          dict({
+            'days': list([
+              dict({
+                'id': 'all_days',
+                'periods': list([
+                  dict({
+                    'duration': 1440.0,
+                    'id': 'normal_1',
+                    'setting': 'AON',
+                    'start': 0.0,
+                    'start_soc': 100.0,
+                    'stop_soc': -1.0,
+                  }),
+                ]),
+                'week_days': 'Mon,Tue,Wed,Thu,Fri,Sat,Sun',
+              }),
+            ]),
+            'end': '12/31',
+            'id': 'always_on',
+            'start': '1/1',
+          }),
+        ]),
+      }),
     }),
     'inverters': dict({
       '482218039091': dict({

--- a/tests/test_generator_write.py
+++ b/tests/test_generator_write.py
@@ -269,7 +269,12 @@ async def test_set_generator_charge_from_generator(
     )
     result = await envoy.set_generator_charge_from_generator(False)
     assert result["charge_from_generator"] is True
-    assert envoy.data.generator_config.charge_from_generator is True
+    # re-read the stored config after the write rather than asserting on
+    # envoy.data.generator_config again: the narrowing from the earlier
+    # is False assertion sticks to that expression, which would make the
+    # rest of this test statically unreachable
+    effective_config = envoy.data.generator_config
+    assert effective_config.charge_from_generator is True
 
     # non-bool values are rejected without sending a request
     with pytest.raises(TypeError):

--- a/tests/test_generator_write.py
+++ b/tests/test_generator_write.py
@@ -1,0 +1,206 @@
+"""Test generator write actions for envoy with an Enpower and standby generator"""
+
+import logging
+from copy import deepcopy
+
+import aiohttp
+import orjson
+import pytest
+from aioresponses import aioresponses
+
+from pyenphase.const import (
+    URL_GEN_CONFIG,
+    URL_GEN_MODE,
+    URL_GEN_SCHEDULE,
+    URL_GENERATOR,
+)
+from pyenphase.envoy import SupportedFeatures
+from pyenphase.exceptions import EnvoyFeatureNotAvailable
+
+from .common import (
+    endpoint_path,
+    get_mock_envoy,
+    latest_request,
+    load_json_fixture,
+    override_mock,
+    prep_envoy,
+    start_7_firmware_mock,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+VERSION = "8.3.5169_with_generator"
+
+
+@pytest.mark.asyncio
+async def test_set_generator_exercise_schedule(
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify setting the exercise schedule sends the round-tripped payload."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
+    assert envoy.supported_features & SupportedFeatures.GENERATOR
+
+    full_host = endpoint_path(VERSION, envoy.host)
+    mock_aioresponse.post(
+        f"{full_host}{URL_GEN_SCHEDULE}", status=200, payload={}, repeat=True
+    )
+
+    await envoy.set_generator_exercise_schedule(
+        freq_in_weeks=2, day="mon", start=840, duration=20
+    )
+
+    # payload is the full GET shape with only exercise_config replaced,
+    # day normalized to the capitalized short name
+    schedule_json = await load_json_fixture(VERSION, "ivp_ss_gen_schedule")
+    expected = deepcopy(schedule_json)
+    expected["exercise_config"] = {
+        "freq_in_weeks": 2,
+        "day": "Mon",
+        "start": 840,
+        "duration": 20,
+    }
+    _cnt, request_data = latest_request(mock_aioresponse, "POST", URL_GEN_SCHEDULE)
+    assert orjson.loads(request_data) == expected
+
+    # internal data is preemptively updated
+    assert envoy.data is not None
+    assert envoy.data.generator_schedule is not None
+    assert envoy.data.generator_schedule.exercise_freq_in_weeks == 2
+    assert envoy.data.generator_schedule.exercise_day == "Mon"
+    assert envoy.data.generator_schedule.exercise_start == 840
+    assert envoy.data.generator_schedule.exercise_duration == 20
+
+    # out of range values are rejected without sending a request
+    with pytest.raises(ValueError):
+        await envoy.set_generator_exercise_schedule(
+            freq_in_weeks=0, day="Mon", start=840, duration=20
+        )
+    with pytest.raises(ValueError):
+        await envoy.set_generator_exercise_schedule(
+            freq_in_weeks=1, day="Monday", start=840, duration=20
+        )
+    with pytest.raises(ValueError):
+        await envoy.set_generator_exercise_schedule(
+            freq_in_weeks=1, day="Mon", start=-1, duration=20
+        )
+    with pytest.raises(ValueError):
+        await envoy.set_generator_exercise_schedule(
+            freq_in_weeks=1, day="Mon", start=1440, duration=20
+        )
+    with pytest.raises(ValueError):
+        await envoy.set_generator_exercise_schedule(
+            freq_in_weeks=1, day="Mon", start=840, duration=0
+        )
+
+    # setting the schedule before the first data update is rejected
+    bad_envoy = await get_mock_envoy(test_client_session, update=False)
+    await bad_envoy.probe()
+    with pytest.raises(ValueError):
+        await bad_envoy.set_generator_exercise_schedule(
+            freq_in_weeks=1, day="Mon", start=840, duration=20
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_generator_charge_from_generator(
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify setting charge from generator sends the round-tripped payload."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
+    assert envoy.supported_features & SupportedFeatures.GENERATOR
+
+    full_host = endpoint_path(VERSION, envoy.host)
+    mock_aioresponse.post(
+        f"{full_host}{URL_GEN_CONFIG}", status=200, payload={}, repeat=True
+    )
+
+    config_json = await load_json_fixture(VERSION, "ivp_ss_gen_config")
+    assert config_json["charge_from_generator"] is True
+
+    for new_value in (False, True):
+        await envoy.set_generator_charge_from_generator(new_value)
+
+        # payload is the full GET shape with only charge_from_generator replaced
+        expected = deepcopy(config_json)
+        expected["charge_from_generator"] = new_value
+        _cnt, request_data = latest_request(mock_aioresponse, "POST", URL_GEN_CONFIG)
+        assert orjson.loads(request_data) == expected
+
+        # internal data is preemptively updated
+        assert envoy.data is not None
+        assert envoy.data.generator_config is not None
+        assert envoy.data.generator_config.charge_from_generator == new_value
+
+    # non-bool values are rejected without sending a request
+    with pytest.raises(TypeError):
+        await envoy.set_generator_charge_from_generator("true")  # type: ignore[arg-type]
+
+    # setting before the first data update is rejected
+    bad_envoy = await get_mock_envoy(test_client_session, update=False)
+    await bad_envoy.probe()
+    with pytest.raises(ValueError):
+        await bad_envoy.set_generator_charge_from_generator(False)
+
+
+@pytest.mark.asyncio
+async def test_generator_write_actions_without_generator(
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify generator write actions are feature gated without a generator."""
+    version = "8.2.127_with_3cts_and_battery_split"
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", version)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
+    assert not envoy.supported_features & SupportedFeatures.GENERATOR
+
+    with pytest.raises(EnvoyFeatureNotAvailable):
+        await envoy.set_generator_exercise_schedule(
+            freq_in_weeks=1, day="Mon", start=840, duration=20
+        )
+    with pytest.raises(EnvoyFeatureNotAvailable):
+        await envoy.set_generator_charge_from_generator(True)
+
+
+@pytest.mark.asyncio
+async def test_set_generator_exercise_schedule_without_gen_schedule(
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify the schedule setter rejects firmware without the gen_schedule endpoint."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    # Simulate a firmware variant with gen_config but no gen_schedule endpoint
+    full_host = endpoint_path(VERSION, "127.0.0.1")
+    for path in (URL_GENERATOR, URL_GEN_SCHEDULE, URL_GEN_MODE):
+        override_mock(
+            mock_aioresponse, "get", f"{full_host}{path}", status=404, repeat=True
+        )
+
+    envoy = await get_mock_envoy(test_client_session)
+    assert envoy.supported_features & SupportedFeatures.GENERATOR
+    assert envoy.data is not None
+    assert envoy.data.generator_schedule is None
+
+    with pytest.raises(EnvoyFeatureNotAvailable):
+        await envoy.set_generator_exercise_schedule(
+            freq_in_weeks=1, day="Mon", start=840, duration=20
+        )

--- a/tests/test_generator_write.py
+++ b/tests/test_generator_write.py
@@ -52,7 +52,10 @@ async def test_set_generator_exercise_schedule(
     )
 
     await envoy.set_generator_exercise_schedule(
-        freq_in_weeks=2, day="mon", start=840, duration=20
+        freq_in_weeks=2,
+        day="mon",
+        start=840,
+        duration=20,
     )
 
     # payload is the full GET shape with only exercise_config replaced,
@@ -95,7 +98,18 @@ async def test_set_generator_exercise_schedule(
         )
     with pytest.raises(ValueError):
         await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=1, day="Mon", start=840, duration=0
+            freq_in_weeks=1, day="Mon", start=840, duration=5
+        )
+    with pytest.raises(ValueError):
+        await envoy.set_generator_exercise_schedule(
+            freq_in_weeks=1, day="Mon", start=840, duration=65
+        )
+    # firmware accepts and persists intermediate values like 25 (verified
+    # live on D8.3.5169) but the Enlighten UI renders them as a blank
+    # duration field, so the library enforces the vendor step-10 domain
+    with pytest.raises(ValueError):
+        await envoy.set_generator_exercise_schedule(
+            freq_in_weeks=1, day="Mon", start=840, duration=25
         )
 
     # setting the schedule before the first data update is rejected

--- a/tests/test_generator_write.py
+++ b/tests/test_generator_write.py
@@ -2,6 +2,7 @@
 
 import logging
 from copy import deepcopy
+from typing import Any
 
 import aiohttp
 import orjson
@@ -15,7 +16,7 @@ from pyenphase.const import (
     URL_GENERATOR,
 )
 from pyenphase.envoy import SupportedFeatures
-from pyenphase.exceptions import EnvoyFeatureNotAvailable
+from pyenphase.exceptions import EnvoyCommunicationError, EnvoyFeatureNotAvailable
 
 from .common import (
     endpoint_path,
@@ -155,32 +156,6 @@ async def test_update_generator_schedule_twice_before_update(
 
 
 @pytest.mark.asyncio
-async def test_update_generator_schedule_reply_without_schedule(
-    caplog: pytest.LogCaptureFixture,
-    mock_aioresponse: aioresponses,
-    test_client_session: aiohttp.ClientSession,
-) -> None:
-    """Verify data is updated from the request if the Envoy returns no schedule."""
-    start_7_firmware_mock(mock_aioresponse)
-    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
-    caplog.set_level(logging.DEBUG)
-
-    envoy = await get_mock_envoy(test_client_session)
-    full_host = endpoint_path(VERSION, envoy.host)
-    mock_aioresponse.post(
-        f"{full_host}{URL_GEN_SCHEDULE}", status=200, payload={}, repeat=True
-    )
-
-    result = await envoy.update_generator_schedule({"exercise_duration": 50})
-
-    assert result == {}
-    assert envoy.data is not None
-    assert envoy.data.generator_schedule is not None
-    assert envoy.data.generator_schedule.exercise_duration == 50
-    assert envoy.data.raw[URL_GEN_SCHEDULE]["exercise_config"]["duration"] == 50
-
-
-@pytest.mark.asyncio
 async def test_update_generator_schedule_validation(
     caplog: pytest.LogCaptureFixture,
     mock_aioresponse: aioresponses,
@@ -207,9 +182,24 @@ async def test_update_generator_schedule_validation(
         {"default_start_soc": 101},
         {"default_stop_soc": -1},
         {"exercise_days": "Mon"},
+        # the generator starts at the low SOC and stops at the high one
+        {"default_start_soc": 80},
+        {"default_stop_soc": 20},
+        {"default_start_soc": 60, "default_stop_soc": 40},
+        {"default_start_soc": 50, "default_stop_soc": 50},
     ):
         with pytest.raises(ValueError):
             await envoy.update_generator_schedule(invalid)
+
+    # a valid pair is accepted, verified against the stored value for the
+    # setting that is not changed
+    assert envoy.data is not None
+    assert envoy.data.generator_schedule is not None
+    assert envoy.data.generator_schedule.default_stop_soc == 70
+    validated = envoy._validated_generator_schedule(
+        {"default_start_soc": 40}, envoy.data.generator_schedule
+    )
+    assert validated == {"default_start_soc": 40}
 
     # nothing was sent to the Envoy
     cnt, _data = latest_request(mock_aioresponse, "POST", URL_GEN_SCHEDULE)
@@ -288,31 +278,6 @@ async def test_set_generator_charge_from_generator(
 
 
 @pytest.mark.asyncio
-async def test_set_generator_charge_from_generator_reply_without_config(
-    caplog: pytest.LogCaptureFixture,
-    mock_aioresponse: aioresponses,
-    test_client_session: aiohttp.ClientSession,
-) -> None:
-    """Verify data is updated from the request if the Envoy returns no config."""
-    start_7_firmware_mock(mock_aioresponse)
-    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
-    caplog.set_level(logging.DEBUG)
-
-    envoy = await get_mock_envoy(test_client_session)
-    full_host = endpoint_path(VERSION, envoy.host)
-    mock_aioresponse.post(
-        f"{full_host}{URL_GEN_CONFIG}", status=200, payload={}, repeat=True
-    )
-
-    await envoy.set_generator_charge_from_generator(False)
-
-    assert envoy.data is not None
-    assert envoy.data.generator_config is not None
-    assert envoy.data.generator_config.charge_from_generator is False
-    assert envoy.data.raw[URL_GEN_CONFIG]["charge_from_generator"] is False
-
-
-@pytest.mark.asyncio
 async def test_generator_write_actions_without_generator(
     caplog: pytest.LogCaptureFixture,
     mock_aioresponse: aioresponses,
@@ -358,3 +323,184 @@ async def test_update_generator_schedule_without_gen_schedule(
 
     with pytest.raises(EnvoyFeatureNotAvailable):
         await envoy.update_generator_schedule({"exercise_duration": 20})
+
+
+@pytest.mark.parametrize(
+    ("reply", "reason"),
+    [
+        ([], "not a document"),
+        ({}, "sentinel key missing"),
+        ({"exercise_config": {"freq_in_weeks": 1}}, "document incomplete"),
+    ],
+    ids=["not_a_document", "sentinel_missing", "incomplete"],
+)
+@pytest.mark.asyncio
+async def test_update_generator_schedule_incomplete_reply(
+    reply: Any,
+    reason: str,
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify stored data is kept if the Envoy returns no complete schedule."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
+    schedule_json = await load_json_fixture(VERSION, "ivp_ss_gen_schedule")
+    full_host = endpoint_path(VERSION, envoy.host)
+    mock_aioresponse.post(
+        f"{full_host}{URL_GEN_SCHEDULE}", status=200, payload=reply, repeat=True
+    )
+
+    with pytest.raises(EnvoyCommunicationError):
+        await envoy.update_generator_schedule({"exercise_duration": 50})
+
+    # data is left at the last known state, not at an optimistic one
+    assert envoy.data is not None
+    assert envoy.data.generator_schedule is not None
+    assert (
+        envoy.data.generator_schedule.exercise_duration
+        == schedule_json["exercise_config"]["duration"]
+    )
+    assert envoy.data.raw[URL_GEN_SCHEDULE] == schedule_json
+
+
+@pytest.mark.parametrize(
+    ("reply", "reason"),
+    [
+        ([], "not a document"),
+        ({}, "sentinel key missing"),
+        ({"charge_from_generator": False}, "document incomplete"),
+    ],
+    ids=["not_a_document", "sentinel_missing", "incomplete"],
+)
+@pytest.mark.asyncio
+async def test_set_generator_charge_from_generator_incomplete_reply(
+    reply: Any,
+    reason: str,
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify stored data is kept if the Envoy returns no complete configuration."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
+    config_json = await load_json_fixture(VERSION, "ivp_ss_gen_config")
+    full_host = endpoint_path(VERSION, envoy.host)
+    mock_aioresponse.post(
+        f"{full_host}{URL_GEN_CONFIG}", status=200, payload=reply, repeat=True
+    )
+
+    with pytest.raises(EnvoyCommunicationError):
+        await envoy.set_generator_charge_from_generator(False)
+
+    assert envoy.data is not None
+    assert envoy.data.generator_config is not None
+    assert envoy.data.generator_config.charge_from_generator is True
+    assert envoy.data.raw[URL_GEN_CONFIG] == config_json
+
+
+@pytest.mark.asyncio
+async def test_generator_write_refresh(
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify refresh re-reads the document before merging the changes."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
+    schedule_json = await load_json_fixture(VERSION, "ivp_ss_gen_schedule")
+    config_json = await load_json_fixture(VERSION, "ivp_ss_gen_config")
+    full_host = endpoint_path(VERSION, envoy.host)
+
+    # something else changed the SOC settings since the last data update
+    changed = deepcopy(schedule_json)
+    changed["default_soc"] = {"start_soc": 45, "stop_soc": 85}
+    override_mock(
+        mock_aioresponse,
+        "get",
+        f"{full_host}{URL_GEN_SCHEDULE}",
+        status=200,
+        payload=changed,
+        repeat=True,
+    )
+    sent_back = deepcopy(changed)
+    sent_back["exercise_config"]["duration"] = 50
+    mock_aioresponse.post(
+        f"{full_host}{URL_GEN_SCHEDULE}", status=200, payload=sent_back, repeat=True
+    )
+
+    await envoy.update_generator_schedule({"exercise_duration": 50}, refresh=True)
+
+    # the re-read values are sent, not the stale ones
+    _cnt, request_data = latest_request(mock_aioresponse, "POST", URL_GEN_SCHEDULE)
+    assert orjson.loads(request_data)["default_soc"] == {
+        "start_soc": 45,
+        "stop_soc": 85,
+    }
+
+    # same for the generator configuration
+    changed_config = deepcopy(config_json)
+    changed_config["warm_up_mins"] = 7
+    override_mock(
+        mock_aioresponse,
+        "get",
+        f"{full_host}{URL_GEN_CONFIG}",
+        status=200,
+        payload=changed_config,
+        repeat=True,
+    )
+    config_reply = deepcopy(changed_config)
+    config_reply["charge_from_generator"] = False
+    mock_aioresponse.post(
+        f"{full_host}{URL_GEN_CONFIG}", status=200, payload=config_reply, repeat=True
+    )
+
+    await envoy.set_generator_charge_from_generator(False, refresh=True)
+
+    _cnt, request_data = latest_request(mock_aioresponse, "POST", URL_GEN_CONFIG)
+    assert orjson.loads(request_data)["warm_up_mins"] == 7
+
+
+@pytest.mark.asyncio
+async def test_generator_write_refresh_incomplete(
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify no update is sent if the refresh returns an incomplete document."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
+    full_host = endpoint_path(VERSION, envoy.host)
+
+    for path in (URL_GEN_SCHEDULE, URL_GEN_CONFIG):
+        override_mock(
+            mock_aioresponse,
+            "get",
+            f"{full_host}{path}",
+            status=200,
+            payload={"incomplete": True},
+            repeat=True,
+        )
+
+    with pytest.raises(EnvoyCommunicationError):
+        await envoy.update_generator_schedule({"exercise_duration": 50}, refresh=True)
+    with pytest.raises(EnvoyCommunicationError):
+        await envoy.set_generator_charge_from_generator(False, refresh=True)
+
+    # nothing was sent
+    cnt, _data = latest_request(mock_aioresponse, "POST", URL_GEN_SCHEDULE)
+    assert cnt == 0
+    cnt, _data = latest_request(mock_aioresponse, "POST", URL_GEN_CONFIG)
+    assert cnt == 0

--- a/tests/test_generator_write.py
+++ b/tests/test_generator_write.py
@@ -33,12 +33,12 @@ VERSION = "8.3.5169_with_generator"
 
 
 @pytest.mark.asyncio
-async def test_set_generator_exercise_schedule(
+async def test_update_generator_schedule(
     caplog: pytest.LogCaptureFixture,
     mock_aioresponse: aioresponses,
     test_client_session: aiohttp.ClientSession,
 ) -> None:
-    """Verify setting the exercise schedule sends the round-tripped payload."""
+    """Verify updating single and multiple generator schedule settings."""
     start_7_firmware_mock(mock_aioresponse)
     await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
     caplog.set_level(logging.DEBUG)
@@ -46,84 +46,180 @@ async def test_set_generator_exercise_schedule(
     envoy = await get_mock_envoy(test_client_session)
     assert envoy.supported_features & SupportedFeatures.GENERATOR
 
+    schedule_json = await load_json_fixture(VERSION, "ivp_ss_gen_schedule")
+    full_host = endpoint_path(VERSION, envoy.host)
+
+    # The Envoy replies with the resulting schedule
+    expected = deepcopy(schedule_json)
+    expected["exercise_config"]["day"] = "Mon"
+    mock_aioresponse.post(
+        f"{full_host}{URL_GEN_SCHEDULE}", status=200, payload=expected, repeat=True
+    )
+
+    # a single setting can be changed without passing the others
+    result = await envoy.update_generator_schedule({"exercise_day": "mon"})
+
+    _cnt, request_data = latest_request(mock_aioresponse, "POST", URL_GEN_SCHEDULE)
+    assert orjson.loads(request_data) == expected
+
+    # the reply is returned and used to update both raw and typed data
+    assert result == expected
+    assert envoy.data is not None
+    assert envoy.data.raw[URL_GEN_SCHEDULE] == expected
+    assert envoy.data.generator_schedule is not None
+    assert envoy.data.generator_schedule.exercise_day == "Mon"
+    # untouched settings keep their value
+    assert (
+        envoy.data.generator_schedule.exercise_start
+        == schedule_json["exercise_config"]["start"]
+    )
+    assert (
+        envoy.data.generator_schedule.default_start_soc
+        == schedule_json["default_soc"]["start_soc"]
+    )
+
+    # all settings can still be changed in one go
+    all_settings = deepcopy(expected)
+    all_settings["exercise_config"] = {
+        "freq_in_weeks": 2,
+        "start": 840,
+        "duration": 30,
+        "day": "Sun",
+    }
+    all_settings["default_soc"] = {"start_soc": 35, "stop_soc": 75}
+    override_mock(
+        mock_aioresponse,
+        "post",
+        f"{full_host}{URL_GEN_SCHEDULE}",
+        status=200,
+        payload=all_settings,
+        repeat=True,
+    )
+    await envoy.update_generator_schedule(
+        {
+            "exercise_freq_in_weeks": 2,
+            "exercise_start": 840,
+            "exercise_duration": 30,
+            "exercise_day": "Sun",
+            "default_start_soc": 35,
+            "default_stop_soc": 75,
+        }
+    )
+    _cnt, request_data = latest_request(mock_aioresponse, "POST", URL_GEN_SCHEDULE)
+    assert orjson.loads(request_data) == all_settings
+    assert envoy.data.generator_schedule.exercise_duration == 30
+    assert envoy.data.generator_schedule.default_stop_soc == 75
+
+
+@pytest.mark.asyncio
+async def test_update_generator_schedule_twice_before_update(
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify a second update builds on the first one, not on stale data."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
+    schedule_json = await load_json_fixture(VERSION, "ivp_ss_gen_schedule")
+    full_host = endpoint_path(VERSION, envoy.host)
+
+    first = deepcopy(schedule_json)
+    first["exercise_config"]["day"] = "Mon"
+    mock_aioresponse.post(
+        f"{full_host}{URL_GEN_SCHEDULE}", status=200, payload=first, repeat=True
+    )
+    await envoy.update_generator_schedule({"exercise_day": "Mon"})
+
+    second = deepcopy(first)
+    second["exercise_config"]["duration"] = 40
+    override_mock(
+        mock_aioresponse,
+        "post",
+        f"{full_host}{URL_GEN_SCHEDULE}",
+        status=200,
+        payload=second,
+        repeat=True,
+    )
+    await envoy.update_generator_schedule({"exercise_duration": 40})
+
+    # without an intermediate Envoy.update the second request must still
+    # carry the day set by the first one
+    _cnt, request_data = latest_request(mock_aioresponse, "POST", URL_GEN_SCHEDULE)
+    sent = orjson.loads(request_data)
+    assert sent["exercise_config"]["day"] == "Mon"
+    assert sent["exercise_config"]["duration"] == 40
+    assert sent == second
+
+
+@pytest.mark.asyncio
+async def test_update_generator_schedule_reply_without_schedule(
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify data is updated from the request if the Envoy returns no schedule."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
     full_host = endpoint_path(VERSION, envoy.host)
     mock_aioresponse.post(
         f"{full_host}{URL_GEN_SCHEDULE}", status=200, payload={}, repeat=True
     )
 
-    await envoy.set_generator_exercise_schedule(
-        freq_in_weeks=2,
-        day="mon",
-        start=840,
-        duration=20,
-    )
+    result = await envoy.update_generator_schedule({"exercise_duration": 50})
 
-    # payload is the full GET shape with only exercise_config replaced,
-    # day normalized to the capitalized short name
-    schedule_json = await load_json_fixture(VERSION, "ivp_ss_gen_schedule")
-    expected = deepcopy(schedule_json)
-    expected["exercise_config"] = {
-        "freq_in_weeks": 2,
-        "day": "Mon",
-        "start": 840,
-        "duration": 20,
-    }
-    _cnt, request_data = latest_request(mock_aioresponse, "POST", URL_GEN_SCHEDULE)
-    assert orjson.loads(request_data) == expected
-
-    # internal data is preemptively updated
+    assert result == {}
     assert envoy.data is not None
     assert envoy.data.generator_schedule is not None
-    assert envoy.data.generator_schedule.exercise_freq_in_weeks == 2
-    assert envoy.data.generator_schedule.exercise_day == "Mon"
-    assert envoy.data.generator_schedule.exercise_start == 840
-    assert envoy.data.generator_schedule.exercise_duration == 20
+    assert envoy.data.generator_schedule.exercise_duration == 50
+    assert envoy.data.raw[URL_GEN_SCHEDULE]["exercise_config"]["duration"] == 50
 
-    # out of range values are rejected without sending a request
-    with pytest.raises(ValueError):
-        await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=0, day="Mon", start=840, duration=20
-        )
-    # the official app's frequency domain is every 1-4 weeks
-    with pytest.raises(ValueError):
-        await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=5, day="Mon", start=840, duration=20
-        )
-    with pytest.raises(ValueError):
-        await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=1, day="Monday", start=840, duration=20
-        )
-    with pytest.raises(ValueError):
-        await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=1, day="Mon", start=-1, duration=20
-        )
-    with pytest.raises(ValueError):
-        await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=1, day="Mon", start=1440, duration=20
-        )
-    with pytest.raises(ValueError):
-        await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=1, day="Mon", start=840, duration=5
-        )
-    with pytest.raises(ValueError):
-        await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=1, day="Mon", start=840, duration=65
-        )
-    # firmware accepts and persists intermediate values like 25 (verified
-    # live on D8.3.5169) but the Enlighten UI renders them as a blank
-    # duration field, so the library enforces the vendor step-10 domain
-    with pytest.raises(ValueError):
-        await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=1, day="Mon", start=840, duration=25
-        )
 
-    # setting the schedule before the first data update is rejected
+@pytest.mark.asyncio
+async def test_update_generator_schedule_validation(
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify generator schedule settings are validated before sending."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
+
+    for invalid in (
+        {"exercise_freq_in_weeks": 0},
+        {"exercise_freq_in_weeks": 5},
+        {"exercise_day": "Monday"},
+        {"exercise_start": -1},
+        {"exercise_start": 1440},
+        {"exercise_duration": 5},
+        {"exercise_duration": 65},
+        # firmware accepts intermediate durations but Enlighten can not
+        # display them, so the vendor step-10 domain is enforced
+        {"exercise_duration": 25},
+        {"default_start_soc": 101},
+        {"default_stop_soc": -1},
+        {"exercise_days": "Mon"},
+    ):
+        with pytest.raises(ValueError):
+            await envoy.update_generator_schedule(invalid)
+
+    # nothing was sent to the Envoy
+    cnt, _data = latest_request(mock_aioresponse, "POST", URL_GEN_SCHEDULE)
+    assert cnt == 0
+
+    # updating before the first data update is rejected
     bad_envoy = await get_mock_envoy(test_client_session, update=False)
     await bad_envoy.probe()
     with pytest.raises(ValueError):
-        await bad_envoy.set_generator_exercise_schedule(
-            freq_in_weeks=1, day="Mon", start=840, duration=20
-        )
+        await bad_envoy.update_generator_schedule({"exercise_duration": 20})
 
 
 @pytest.mark.asyncio
@@ -132,7 +228,7 @@ async def test_set_generator_charge_from_generator(
     mock_aioresponse: aioresponses,
     test_client_session: aiohttp.ClientSession,
 ) -> None:
-    """Verify setting charge from generator sends the round-tripped payload."""
+    """Verify setting charge from generator sends the full configuration."""
     start_7_firmware_mock(mock_aioresponse)
     await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
     caplog.set_level(logging.DEBUG)
@@ -140,27 +236,40 @@ async def test_set_generator_charge_from_generator(
     envoy = await get_mock_envoy(test_client_session)
     assert envoy.supported_features & SupportedFeatures.GENERATOR
 
-    full_host = endpoint_path(VERSION, envoy.host)
-    mock_aioresponse.post(
-        f"{full_host}{URL_GEN_CONFIG}", status=200, payload={}, repeat=True
-    )
-
     config_json = await load_json_fixture(VERSION, "ivp_ss_gen_config")
     assert config_json["charge_from_generator"] is True
+    full_host = endpoint_path(VERSION, envoy.host)
 
-    for new_value in (False, True):
-        await envoy.set_generator_charge_from_generator(new_value)
+    disabled = deepcopy(config_json)
+    disabled["charge_from_generator"] = False
+    mock_aioresponse.post(
+        f"{full_host}{URL_GEN_CONFIG}", status=200, payload=disabled, repeat=True
+    )
 
-        # payload is the full GET shape with only charge_from_generator replaced
-        expected = deepcopy(config_json)
-        expected["charge_from_generator"] = new_value
-        _cnt, request_data = latest_request(mock_aioresponse, "POST", URL_GEN_CONFIG)
-        assert orjson.loads(request_data) == expected
+    result = await envoy.set_generator_charge_from_generator(False)
 
-        # internal data is preemptively updated
-        assert envoy.data is not None
-        assert envoy.data.generator_config is not None
-        assert envoy.data.generator_config.charge_from_generator == new_value
+    # the whole configuration is sent with only the one field changed
+    _cnt, request_data = latest_request(mock_aioresponse, "POST", URL_GEN_CONFIG)
+    assert orjson.loads(request_data) == disabled
+
+    assert result == disabled
+    assert envoy.data is not None
+    assert envoy.data.raw[URL_GEN_CONFIG] == disabled
+    assert envoy.data.generator_config is not None
+    assert envoy.data.generator_config.charge_from_generator is False
+
+    # a system that normalizes the value back reports the effective value
+    override_mock(
+        mock_aioresponse,
+        "post",
+        f"{full_host}{URL_GEN_CONFIG}",
+        status=200,
+        payload=config_json,
+        repeat=True,
+    )
+    result = await envoy.set_generator_charge_from_generator(False)
+    assert result["charge_from_generator"] is True
+    assert envoy.data.generator_config.charge_from_generator is True
 
     # non-bool values are rejected without sending a request
     with pytest.raises(TypeError):
@@ -171,6 +280,31 @@ async def test_set_generator_charge_from_generator(
     await bad_envoy.probe()
     with pytest.raises(ValueError):
         await bad_envoy.set_generator_charge_from_generator(False)
+
+
+@pytest.mark.asyncio
+async def test_set_generator_charge_from_generator_reply_without_config(
+    caplog: pytest.LogCaptureFixture,
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify data is updated from the request if the Envoy returns no config."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+    caplog.set_level(logging.DEBUG)
+
+    envoy = await get_mock_envoy(test_client_session)
+    full_host = endpoint_path(VERSION, envoy.host)
+    mock_aioresponse.post(
+        f"{full_host}{URL_GEN_CONFIG}", status=200, payload={}, repeat=True
+    )
+
+    await envoy.set_generator_charge_from_generator(False)
+
+    assert envoy.data is not None
+    assert envoy.data.generator_config is not None
+    assert envoy.data.generator_config.charge_from_generator is False
+    assert envoy.data.raw[URL_GEN_CONFIG]["charge_from_generator"] is False
 
 
 @pytest.mark.asyncio
@@ -189,20 +323,18 @@ async def test_generator_write_actions_without_generator(
     assert not envoy.supported_features & SupportedFeatures.GENERATOR
 
     with pytest.raises(EnvoyFeatureNotAvailable):
-        await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=1, day="Mon", start=840, duration=20
-        )
+        await envoy.update_generator_schedule({"exercise_duration": 20})
     with pytest.raises(EnvoyFeatureNotAvailable):
         await envoy.set_generator_charge_from_generator(True)
 
 
 @pytest.mark.asyncio
-async def test_set_generator_exercise_schedule_without_gen_schedule(
+async def test_update_generator_schedule_without_gen_schedule(
     caplog: pytest.LogCaptureFixture,
     mock_aioresponse: aioresponses,
     test_client_session: aiohttp.ClientSession,
 ) -> None:
-    """Verify the schedule setter rejects firmware without the gen_schedule endpoint."""
+    """Verify the schedule update rejects firmware without the gen_schedule endpoint."""
     start_7_firmware_mock(mock_aioresponse)
     await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
     caplog.set_level(logging.DEBUG)
@@ -220,6 +352,4 @@ async def test_set_generator_exercise_schedule_without_gen_schedule(
     assert envoy.data.generator_schedule is None
 
     with pytest.raises(EnvoyFeatureNotAvailable):
-        await envoy.set_generator_exercise_schedule(
-            freq_in_weeks=1, day="Mon", start=840, duration=20
-        )
+        await envoy.update_generator_schedule({"exercise_duration": 20})

--- a/tests/test_generator_write.py
+++ b/tests/test_generator_write.py
@@ -84,6 +84,11 @@ async def test_set_generator_exercise_schedule(
         await envoy.set_generator_exercise_schedule(
             freq_in_weeks=0, day="Mon", start=840, duration=20
         )
+    # the official app's frequency domain is every 1-4 weeks
+    with pytest.raises(ValueError):
+        await envoy.set_generator_exercise_schedule(
+            freq_in_weeks=5, day="Mon", start=840, duration=20
+        )
     with pytest.raises(ValueError):
         await envoy.set_generator_exercise_schedule(
             freq_in_weeks=1, day="Monday", start=840, duration=20


### PR DESCRIPTION
Ready for review — the #472 dependency is satisfied. #472 merged, and this branch has been rebased onto main (currently at the 3.1.0 release). The diff is now exactly this PR's own work: the two setters, the two vendor-domain validation constraints, and the live-verified docstrings — five commits touching src/pyenphase/envoy.py, src/pyenphase/const.py, docs/data_ensemble.md, and a new tests/test_generator_write.py. Nothing in the merged form of #472 required adapting this work.



## What

Completes the generator write surface started with
`Envoy.set_generator_mode` (#472) with two more setters, mirroring its
design (GENERATOR feature gate, validation before any request,
preemptive internal-data update, POST like the sibling `/ivp/ss/`
writes gen_mode and dry_contact_settings):

- `Envoy.set_generator_exercise_schedule(*, freq_in_weeks, day, start,
  duration)` — POSTs to `/ivp/ss/gen_schedule`. The body round-trips
  the full GET payload as last read from the Envoy with only the
  `exercise_config` fields replaced; `default_soc`, the nested
  `schedule` block and `last_updated_by` are sent back unchanged, since
  partial updates may not be supported (same reasoning as
  `update_dry_contact`, which sends the whole settings object).
  Validation: `freq_in_weeks` 1-4 (the official app's every-1-4-weeks
  domain; firmware behavior for larger values untested), `day` in
  Mon..Sun short names (case-insensitive input, normalized to the
  capitalized form both firmware fixtures report), `start` 0-1439
  minutes after midnight,
  `duration` 10-60 minutes in steps of 10, matching the official
  Enphase app (firmware accepts intermediate values, but Enlighten
  cannot display them — see Live verification below — so the library
  enforces the vendor domain). Raises `EnvoyFeatureNotAvailable` on firmware that
  does not expose the gen_schedule endpoint (see the per-endpoint
  availability probing from #472).
- `Envoy.set_generator_charge_from_generator(bool)` — POSTs to
  `/ivp/ss/gen_config`, round-tripping the full GET payload with only
  `charge_from_generator` replaced. The remaining gen_config fields
  (name plate rating, max continuous amps, generator
  type/model/manufacturer, start method) are installer-grade settings
  and are deliberately NOT settable through this library. Note: on
  battery-less systems the firmware accepts this write but silently
  normalizes the flag back to true (see Live verification).
- New constant `GENERATOR_EXERCISE_DAYS` in `const.py`.
- Docs: setter references added to the generator section of
  `docs/data_ensemble.md`.

## Why

#106 asked for generator control endpoints; #472 delivers telemetry for
all of them plus gen_mode control. This adds the remaining safe write
operations so integrations (e.g. Home Assistant) can manage the
exercise schedule and charge-from-generator behavior — the two
homeowner-facing settings the Enphase app exposes.

## Tests

New `tests/test_generator_write.py`:
- exercise-schedule setter: exact URL + payload (full round-tripped GET
  shape with only exercise_config replaced), day-casing normalization,
  preemptive internal-data update, all range validations, pre-first-update
  ValueError
- charge-from-generator setter: exact payload for both bool values,
  preemptive update, TypeError on non-bool, pre-first-update ValueError
- feature-gate negatives on a no-generator Enpower system
- schedule setter raises `EnvoyFeatureNotAvailable` on the
  partial-endpoint firmware variant (gen_config only)

Full suite green, 100% coverage maintained, ruff clean, mypy unchanged
(only the pre-existing envoy.py/firmware.py errors). No EnvoyData shape
change, so no snapshot updates.

## Live verification (2026-07-30, Envoy D8.3.5169)

Verified against real hardware via a Home Assistant custom-component
override calling these setters from real UI entities, with the
generator physically isolated (mode off, manual, emergency disconnect
open) throughout:

- `set_generator_exercise_schedule`: **POST accepted and persisted.**
  Changed live: day Thu→Sat, start 810→945 (13:30→15:45), duration
  10→25, freq unchanged at 1. Read back verbatim from
  `GET /ivp/ss/gen_schedule` and stable across multiple poll cycles.
  The POST verb and the round-tripped body shape are confirmed correct.
- **Vendor-domain discovery — duration:** the official Enphase app
  constrains exercise duration to 10-60 minutes in steps of 10. The
  firmware accepted and persisted the intermediate value 25, and the
  value synced to the cloud — but the Enlighten portal UI rendered the
  duration field BLANK (its dropdown only has 10/20/30/40/50/60). The
  hardware is more permissive than the vendor UI, yet writing
  intermediate values leaves the official app unable to display the
  setting, so the setter enforces 10-60 in steps of 10 (ValueError
  otherwise).
- **Confirmed side effect — schedule writes (re)apply `default_soc`:**
  immediately after the schedule POST,
  `GET /ivp/ensemble/generator` showed `start_soc`/`stop_soc` change
  from 100/-1 to 30/70 — the firmware applied the echoed `default_soc`
  block as the ACTIVE generator SOC settings. Inert on this
  battery-less system, but battery owners should know that writing the
  exercise schedule also (re)applies the default start/stop SOC.
- **End-to-end frequency verification:** exercise frequency was
  additionally changed live from HA (freq → 3), instant at the
  controller (18:34Z) and rendered in Enlighten — completing live
  verification of every schedule field (day, start, duration, freq).
- `set_generator_charge_from_generator`: **write path verified
  end-to-end, with a firmware normalization finding.** Tested three
  ways on this battery-less system (HA switch UI, HA service call, and
  a raw curl POST of the full round-tripped gen_config with only the
  flag set false). All three: HTTP 200, but the firmware silently
  normalizes `charge_from_generator` back to `true` — the POST response
  body (which echoes the resulting effective config) already showed
  `true`, and read-backs confirm no change persists. On systems without
  Enphase batteries the endpoint ACCEPTS-AND-IGNORES this field rather
  than rejecting the request.

## Notes for reviewers

- **Schedule writes (re)apply the echoed `default_soc` block** (see
  live verification above). Open design note: a future refinement could
  fetch a fresh gen_schedule inside the setter and modify that, rather
  than echoing the last-polled copy, to minimize the window in which a
  stale `default_soc`/`schedule` block is re-applied — happy to go
  either way per maintainer preference.
- **The POST response echoes the EFFECTIVE config**, so a caller can
  detect accepted-but-ignored writes (like the battery-less
  `charge_from_generator` normalization above) by comparing the
  response to the request. Open question for the maintainer: should
  `set_generator_charge_from_generator` surface that — e.g. return or
  expose the effective value from the response — or is documenting the
  caveat (as the docstring now does) sufficient? Happy to implement
  either.
- Both setter docstrings have been updated in-code to reflect the live
  verification (schedule: verified/persisted/synced + the `default_soc`
  re-apply note; charge: the battery-less normalization caveat).
- Open to renaming/reshaping the API (e.g. a single `update_gen_config`
  dict-style setter like `update_dry_contact`) if preferred — the
  narrow setters were chosen to keep installer-grade fields read-only.

## Live-verification checklist

1. ~~Baseline read of `GET /ivp/ss/gen_schedule` and
   `GET /ivp/ss/gen_config`~~ — **DONE 2026-07-30**
2. ~~`set_generator_exercise_schedule` write accepted (HTTP success)~~ —
   **DONE 2026-07-30** (day Thu→Sat, start 810→945, duration 10→25)
3. ~~Read back from `GET /ivp/ss/gen_schedule`: written values returned
   verbatim and persisted across multiple poll cycles~~ —
   **DONE 2026-07-30** (also surfaced the `default_soc` re-apply side
   effect on `/ivp/ensemble/generator`, documented above)
4. ~~`set_generator_charge_from_generator`: flip the flag and verify~~ —
   **DONE 2026-07-30**: write path verified end-to-end; firmware
   normalizes the flag to true on battery-less systems
   (accept-and-ignore, HTTP 200)

**All checklist items are closed — no hardware gates remain.** The
former "retry with PUT on rejection" step is dropped: POST is confirmed
accepted by the firmware. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring generator exercise schedules, including frequency, days, start time, and duration.
  * Added controls to enable or disable battery charging from the generator.
  * Added optional refreshes before applying generator configuration changes.
  * Added validation and normalization for supported settings, value ranges, and state-of-charge limits.
  * Improved updates to preserve complete configuration and synchronize returned settings.

* **Bug Fixes**
  * Prevented cached generator settings from being replaced when responses are incomplete or invalid.

* **Documentation**
  * Expanded guidance on scheduling, battery charging, response verification, and state-of-charge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->