### PR TITLE
chore: issue-manager runs report missing typing_extensions since #461

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1942,16 +1942,16 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
-markers = "python_version < \"3.13\""
+groups = ["main", "dev", "issue-manager"]
 files = [
-    {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
-    {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
+    {file = "typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"},
+    {file = "typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"},
 ]
+markers = {main = "python_version < \"3.13\"", dev = "python_version < \"3.13\""}
 
 [[package]]
 name = "urllib3"
@@ -2196,4 +2196,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "9e4d291384892313f63a720f68ab51b033c000e870ec175a470a16ac49386745"
+content-hash = "773aebbe22a0f6a7a44e7ae53eeb00cd84dd096a1223cdbc938c4164db51e4b2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ sphinx = ">=4.0"
 sphinx-rtd-theme = ">=1.0"
 sphinx-autodoc-typehints = ">=1.25.2,<4.0.0"
 
+[tool.poetry.group.issue-manager.dependencies]
+typing-extensions = "^4.16.0"
+
 [tool.semantic_release]
 branch = "main"
 version_toml = ["pyproject.toml:project.version", "pyproject.toml:tool.poetry.version"]


### PR DESCRIPTION
With PR #461 tiangolo/issue-manager updated from 0.6.0 to 0.8.0.Ecer since that update github job issue-manager starting reporting issues

```
Traceback (most recent call last):
  File "/code/app/main.py", line 5, in <module>
    from typing_extensions import Literal
ModuleNotFoundError: No module named 'typing_extensions'
```

This PR attempts to repair by installing this before it runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an optional dependency group for issue-management tooling.
  * Included `typing-extensions` version 4.16.0 or later in the group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->