### PR TITLE
fix: return None for individual phases if combined activeCount and total=net consumption occurs

### DIFF
--- a/docs/data_consumption.md
+++ b/docs/data_consumption.md
@@ -29,12 +29,14 @@ For [metered Envoy with multi-phase installations](./phase_data.md#phase-data), 
                 print(f'{phase} LifetimeEnergy {phase_data.watt_hours_lifetime}')
                 print(f'{phase} Last7DaysEnergy {phase_data.watt_hours_last_7_days}')
 
-        # report specific phase data by using PhaseNames (for phase 1)
-        if (phase_data := data.system_consumption_phases[[PhaseNames.PHASE_1]]):
+    # report specific phase data by using PhaseNames (for phase 1)
+    if envoy.phase_count > 1 and data.system_consumption_phases:
+        if (phase_data := data.system_consumption_phases[PhaseNames.PHASE_1]):
             print(f'Value watt_hours_lifetime : {phase_data.watt_hours_lifetime}')
 
-        # report specific phase data by using phase index 0-2 (for phase 1)
-        if (phase_data := data.system_consumption_phases[[PhaseNames.PHASE_1]]):
+    # report specific phase data by using phase index 0-2 (for phase 1)
+    if envoy.phase_count > 1 and data.system_consumption_phases:
+        if (phase_data := data.system_consumption_phases[PHASENAMES[0]]):
             print(f'Value watt_hours_lifetime : {phase_data.watt_hours_lifetime}')
 ```
 

--- a/docs/data_consumption.md
+++ b/docs/data_consumption.md
@@ -23,16 +23,19 @@ For [metered Envoy with multi-phase installations](./phase_data.md#phase-data), 
 
     if envoy.phase_count > 1 and data.system_consumption_phases:
         for phase in data.system_consumption_phases:
-            print(f'{phase} Watts: {data.system_consumption_phases[phase].watts_now}')
-            print(f'{phase} TodaysEnergy: {data.system_consumption_phases[phase].watt_hours_today}')
-            print(f'{phase} LifetimeEnergy {data.system_consumption_phases[phase].watt_hours_lifetime}')
-            print(f'{phase} Last7DaysEnergy {data.system_consumption_phases[phase].watt_hours_last_7_days}')
+            if (phase_data := data.system_consumption_phases[phase]):
+                print(f'{phase} Watts: {phase_data.watts_now}')
+                print(f'{phase} TodaysEnergy: {phase_data.watt_hours_today}')
+                print(f'{phase} LifetimeEnergy {phase_data.watt_hours_lifetime}')
+                print(f'{phase} Last7DaysEnergy {phase_data.watt_hours_last_7_days}')
 
-        # report specific phase data  by using PhaseNames (for phase 1)
-        print(f'Value watt_hours_lifetime : {data.system_consumption_phases[PhaseNames.PHASE_1].watt_hours_lifetime}')
+        # report specific phase data by using PhaseNames (for phase 1)
+        if (phase_data := data.system_consumption_phases[[PhaseNames.PHASE_1]]):
+            print(f'Value watt_hours_lifetime : {phase_data.watt_hours_lifetime}')
 
         # report specific phase data by using phase index 0-2 (for phase 1)
-        print(f'Value watt_hours_lifetime : {data.system_consumption_phases[PHASENAMES[0]].watt_hours_lifetime}')
+        if (phase_data := data.system_consumption_phases[[PhaseNames.PHASE_1]]):
+            print(f'Value watt_hours_lifetime : {phase_data.watt_hours_lifetime}')
 ```
 
 ## Data sources

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -69,4 +69,4 @@ A silent fallback from production to inverters data section of /production then 
 
 The library detects the situation and will not fallback to the faulty data, instead it will return None in the system_production data record. None will be returned as long as activeCount remains zero. In prior versions (incorrect) data from the /api/v1/production endpoint was returned.
 
-If the Envoy firmware is also [reporting total consumption as net-consumption](#consumption-data-set-to-net-consumption-data-in-835433), aggregate consumption data will be reported as None and the phase data reports each individual phase as None. This because no reliable production data is available to apply the needed correction.
+If the Envoy firmware is also [reporting total consumption as net-consumption](#consumption-data-set-to-net-consumption-data-in-835433), aggregate consumption data will be reported as None and the phase data for multiphase systems reports each individual phase as None. This is because no reliable production data is available to apply the needed correction.

--- a/docs/known_issues.md
+++ b/docs/known_issues.md
@@ -59,6 +59,8 @@ For anyone already running 8.3.5433, the consumption total has previously droppe
 
 As of 8.3.5422, the Standard Envoy, not-metered type, reports all zeros in its /api/v1/production endpoint. The library detects the situation and switches to using the inverters data section of the /production endpoint. The inverters section is lacking Today and Last 7 days values, these will be set to zero.
 
+(activecount_zero)=
+
 ## Envoy metered silently falls back to inverter data from /production in 5.3.5528
 
 As of firmware 5.3.5528 (and maybe earlier) metered envoy with production CT installed, intermittently report bogus data in /production type=eim section, recognizable by activeCount: 0.
@@ -67,4 +69,4 @@ A silent fallback from production to inverters data section of /production then 
 
 The library detects the situation and will not fallback to the faulty data, instead it will return None in the system_production data record. None will be returned as long as activeCount remains zero. In prior versions (incorrect) data from the /api/v1/production endpoint was returned.
 
-If the Envoy firmware is also [reporting total consumption as net-consumption](#consumption-data-set-to-net-consumption-data-in-835433), consumption data for aggregate and phase data will be reported as None as well. This because no reliable production data is available to apply the needed correction.
+If the Envoy firmware is also [reporting total consumption as net-consumption](#consumption-data-set-to-net-consumption-data-in-835433), aggregate consumption data will be reported as None and the phase data reports each individual phase as None. This because no reliable production data is available to apply the needed correction.

--- a/src/pyenphase/models/envoy.py
+++ b/src/pyenphase/models/envoy.py
@@ -64,7 +64,9 @@ class EnvoyData:
     #: Solar Production power & energy values
     system_production: EnvoySystemProduction | None = None
     #: Individual phase consumption power & energy values, keyed by :any:`PhaseNames`,
-    #: only for Envoy metered with CT installed
+    #: only for Envoy metered with CT installed.
+    #: A phase entry may be None when the library judges the reading invalid,
+    #: see :ref:`activecount_zero`.
     system_consumption_phases: dict[str, EnvoySystemConsumption | None] | None = None
     #: Individual phase solar production power & energy values, keyed by :any:`PhaseNames`,
     #: only for Envoy metered with CT installed
@@ -83,9 +85,9 @@ class EnvoyData:
     #: see :ref:`storage-ct-zero-phase_and-agg-drop`
     ctmeters: dict[str, EnvoyMeterData | None] = field(default_factory=dict)
     #: CT power & energy phase values, only for Envoy metered with CT installed.
-    #: Keyed by :any:`CtType` and  :any:`PhaseNames`
-    #: An phase entry may be None when the library judges the reading invalid,
-    #: see :ref:`storage-ct-zero-phase_and-agg-drop`
+    #: Keyed by :any:`CtType` and  :any:`PhaseNames`.
+    #: A phase entry may be None when the library judges the reading invalid,
+    #: see :ref:`storage-ct-zero-phase_and-agg-drop`.
     ctmeters_phases: dict[str, dict[str, EnvoyMeterData | None]] = field(
         default_factory=dict
     )

--- a/src/pyenphase/updaters/production.py
+++ b/src/pyenphase/updaters/production.py
@@ -280,7 +280,13 @@ class EnvoyProductionUpdater(EnvoyUpdater):
                     "No reliable production data found, cannot correct consumption data, returning None."
                 )
                 envoy_data.system_consumption = None
-                envoy_data.system_consumption_phases = None
+
+                # set individual phases to None rather then overall phase record so phases
+                # are present with None data and HA will create entities when this
+                # combined issue occurs at start/reload
+                if envoy_data.system_consumption_phases:
+                    for cons_phase in envoy_data.system_consumption_phases:
+                        envoy_data.system_consumption_phases[cons_phase] = None
             else:
                 # Add production to net-consumption to get total-consumption
                 # we're only here if net = tot consumption so we can use either

--- a/tests/test_ct_meters.py
+++ b/tests/test_ct_meters.py
@@ -1524,7 +1524,7 @@ async def test_intermittent_activecount_regression_total_is_net_consumption(
     # consumption data should be corrected for total=net consumption issue
     assert data.system_consumption is not None
     # no consumption phases for 1 phase system
-    assert data.system_production_phases is None
+    assert data.system_consumption_phases is None
     assert data.system_consumption.watts_now == 428 + 357
     assert data.system_consumption.watt_hours_today == 5649402
     assert data.system_consumption.watt_hours_last_7_days == 5649402

--- a/tests/test_ct_meters.py
+++ b/tests/test_ct_meters.py
@@ -1364,9 +1364,11 @@ async def test_intermittent_activecount_regression_total_is_net_consumption(
     assert data.system_production is None
     assert data.system_production_phases is None
 
-    # consumption data should be none as we have no reliable production values to use for correction
+    # consumption data should be none as we have no reliable production values to use for correction. Phases should be present with None value
     assert data.system_consumption is None
-    assert data.system_consumption_phases is None
+    assert data.system_consumption_phases is not None
+    assert data.system_consumption_phases[PhaseNames.PHASE_1] is None
+    assert data.system_consumption_phases[PhaseNames.PHASE_2] is None
 
     # test restore activeCount back to 1. Should restore production and consumption data
     production_json["production"][1]["activeCount"] = 1
@@ -1400,6 +1402,129 @@ async def test_intermittent_activecount_regression_total_is_net_consumption(
 
     # consumption data should be corrected for total=net consumption issue
     assert data.system_consumption is not None
+    assert data.system_production_phases is not None
+    assert data.system_consumption.watts_now == 428 + 357
+    assert data.system_consumption.watt_hours_today == 5649402
+    assert data.system_consumption.watt_hours_last_7_days == 5649402
+    assert data.system_consumption.watt_hours_lifetime == 5649402 + 14405465
+    assert data.system_consumption_phases is not None
+    assert data.system_consumption_phases[PhaseNames.PHASE_1] is not None
+    assert data.system_consumption_phases[PhaseNames.PHASE_2] is not None
+
+    # test for non-phased case to test branch logic
+    production_json = await load_json_fixture(version, "production.json")
+    del production_json["production"][1]["lines"]
+    del production_json["consumption"][0]["lines"]
+    del production_json["consumption"][1]["lines"]
+
+    override_mock(
+        mock_aioresponse,
+        "get",
+        "https://127.0.0.1/production.json",
+        status=200,
+        payload=production_json,
+        repeat=True,
+    )
+    override_mock(
+        mock_aioresponse,
+        "get",
+        "https://127.0.0.1/production.json?details=1",
+        status=200,
+        payload=production_json,
+        repeat=True,
+    )
+
+    envoy = await get_mock_envoy(test_client_session)
+
+    data = envoy.data
+    assert data is not None
+    assert envoy._supported_features is not None
+
+    assert data.system_production is not None
+    assert data.system_production.watts_now == 357
+    assert data.system_production.watt_hours_today == 14405465
+    assert data.system_production.watt_hours_last_7_days == 14405465
+    assert data.system_production.watt_hours_lifetime == 14405465
+    # no production phases for 1 phase system
+    assert data.system_production_phases is None
+
+    assert data.system_consumption is not None
+    assert data.system_consumption.watts_now == 428 + 357
+    assert data.system_consumption.watt_hours_today == 5649402
+    assert data.system_consumption.watt_hours_last_7_days == 5649402
+    assert data.system_consumption.watt_hours_lifetime == 5649402 + 14405465
+    # no consumption phases for 1 phase system
+    assert data.system_consumption_phases is None
+
+    # Test intermittent activeCount = 0 case during regular operation
+    production_json["production"][1]["activeCount"] = 0
+    override_mock(
+        mock_aioresponse,
+        "get",
+        "https://127.0.0.1/production.json",
+        status=200,
+        payload=production_json,
+        repeat=True,
+    )
+    override_mock(
+        mock_aioresponse,
+        "get",
+        "https://127.0.0.1/production.json?details=1",
+        status=200,
+        payload=production_json,
+        repeat=True,
+    )
+
+    await envoy.update()
+
+    data = envoy.data
+    assert data is not None
+
+    # if activeCount is 0 and Production CT present, None should return for production data
+    assert data.system_production is None
+    # no production phases for 1 phase system
+    assert data.system_production_phases is None
+
+    # consumption data should be none as we have no reliable production values to use for correction
+    assert data.system_consumption is None
+    # no consumption phases for 1 phase system
+    assert data.system_consumption_phases is None
+
+    # test restore activeCount back to 1. Should restore production and consumption data
+    production_json["production"][1]["activeCount"] = 1
+    override_mock(
+        mock_aioresponse,
+        "get",
+        "https://127.0.0.1/production.json",
+        status=200,
+        payload=production_json,
+        repeat=True,
+    )
+    override_mock(
+        mock_aioresponse,
+        "get",
+        "https://127.0.0.1/production.json?details=1",
+        status=200,
+        payload=production_json,
+        repeat=True,
+    )
+    await envoy.update()
+    data = envoy.data
+    assert data is not None
+
+    # With CT active /production data should be from type=eim and not from type=inverters
+    assert data.system_production is not None
+    # no production phases for 1 phase system
+    assert data.system_production_phases is None
+    assert data.system_production.watts_now == 357
+    assert data.system_production.watt_hours_today == 14405465
+    assert data.system_production.watt_hours_last_7_days == 14405465
+    assert data.system_production.watt_hours_lifetime == 14405465
+
+    # consumption data should be corrected for total=net consumption issue
+    assert data.system_consumption is not None
+    # no consumption phases for 1 phase system
+    assert data.system_production_phases is None
     assert data.system_consumption.watts_now == 428 + 357
     assert data.system_consumption.watt_hours_today == 5649402
     assert data.system_consumption.watt_hours_last_7_days == 5649402


### PR DESCRIPTION
Pyenphase [3.2.1](https://github.com/pyenphase/pyenphase/releases#release-v3.2.1) and [4.0.0](https://github.com/pyenphase/pyenphase/releases/tag/v4.0.0) delivered a fix for 2 firmware issues that can result in incorrect data. The fixes in 4.0.0 are designed to return None values to Home Assistant in order to let HA create all needed sensors if the issue would occur when HA starts or reloads the Enphase_envoy integration. 

If both issue happen at the same time during the HA start/reload, Pyenphase currently returns None for the consumption and consumption phase record. A None consumption phase record at start will cause HA to set the storage phase entities to unavailable and prohibits recovery for these when data is available again. Pyenphase should instead return a consumption phase record with all known phases and each phase set to None. That will enable the intended HA recovery when data is available again.

This PR:

- Replaces setting `envoy_data.system_consumption_phases = None` with setting detected phases to None in the combined issue handling in the production updater update method.
- Updates the `test_intermittent_activecount_regression_total_is_net_consumption` test for the expected None values in the phase record rather then the phase record being None.

> ** NOTE ** The data model already allows for None entries in the system_consumption_phases data for both the record itself or the individual phase entries in the record since they were added in version 1.x.. Typed consumers that assume EnvoySystemConsumption will now fail type checks, and untyped consumers can raise AttributeError on None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved total-consumption correction when reliable production data is unavailable by preserving phase mappings while marking individual consumption values as unavailable.
* Corrected handling of invalid or zero production activity so aggregate and phase measurements are cleared consistently.
* Ensured valid measurements are restored correctly after production data becomes available again.

## Documentation

* Clarified handling of missing phase data and invalid consumption readings in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->