### PR TITLE
fix: KeyError 'exercise_config' in generator schedule

### DIFF
--- a/docs/data_ensemble.md
+++ b/docs/data_ensemble.md
@@ -56,14 +56,24 @@ Dry Contact information is available in the [EnvoyData.dry_contact_status](#pyen
 
 ## Generator data
 
-Systems with an Enpower and a standby generator installed report generator data. Availability is signaled by the {py:attr}`pyenphase.const.SupportedFeatures.GENERATOR` supported feature flag.
+Systems with an Enpower and a standby generator installed report generator data. Availability is signaled by the {py:attr}`pyenphase.const.SupportedFeatures.GENERATOR` and {py:attr}`pyenphase.const.SupportedFeatures.GENERATOR_SCHEDULE` supported feature flags.
 
 - Generator status (admin, operational relay state, admin mode, schedule state, generator present) is available in [EnvoyData.generator](#pyenphase.EnvoyData.generator), modeled by [EnvoyGenerator](#pyenphase.models.generator.EnvoyGenerator).
 - Generator configuration (name plate rating, manufacturer, model, start method, warm-up/cool-down minutes) is available in [EnvoyData.generator_config](#pyenphase.EnvoyData.generator_config), modeled by [EnvoyGeneratorConfig](#pyenphase.models.generator.EnvoyGeneratorConfig).
-- The generator exercise schedule and default state-of-charge settings are available in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule), modeled by [EnvoyGeneratorSchedule](#pyenphase.models.generator.EnvoyGeneratorSchedule).
+- The generator exercise schedule and default state-of-charge settings are available in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule), modeled by [EnvoyGeneratorSchedule](#pyenphase.models.generator.EnvoyGeneratorSchedule). The schedule is only available if the {py:attr}`pyenphase.const.SupportedFeatures.GENERATOR_SCHEDULE` flag is set.
 - The generator operation mode ("off", "on" or "auto") is available in [EnvoyData.generator_mode](#pyenphase.EnvoyData.generator_mode), modeled by [EnvoyGeneratorMode](#pyenphase.models.generator.EnvoyGeneratorMode), on firmware exposing the `/ivp/ss/gen_mode` endpoint.
 
 The Envoy class provides the method [Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) to control the generator operation mode, [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) to change the exercise schedule and default state-of-charge settings, and [Envoy.set_generator_charge_from_generator](#pyenphase.Envoy.set_generator_charge_from_generator) to allow or disallow charging batteries from the generator.
+
+---
+
+**NOTE**
+
+The generator schedule will only be available when configured in the Envoy using the Enphase tools. If not setup, the {py:attr}`pyenphase.const.SupportedFeatures.GENERATOR_SCHEDULE` flag will not be set and the {py:attr}`pyenphase.EnvoyData.generator_schedule` will be `None`. The [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) can not be used either until a schedule is configured in the Envoy.
+
+Once a schedule is configured in the Envoy, rerun {py:attr}`pyenphase.Envoy.probe` to make the schedule known in the data model.
+
+---
 
 [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) and [Envoy.set_generator_charge_from_generator](#pyenphase.Envoy.set_generator_charge_from_generator) send the whole document to the Envoy, as these endpoints do not support partial updates. The document is built from the data in [EnvoyData](#pyenphase.EnvoyData), with only the specified settings changed. ([Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) is a single command endpoint and does not work this way.) [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) takes a dict of settings to change, so a single setting can be changed without specifying the others:
 
@@ -98,8 +108,7 @@ if envoy.data.generator_mode:
 if envoy.data.generator_config:
     print(f"Generator: {envoy.data.generator_config.manufacturer} {envoy.data.generator_config.model}")
 
-if envoy.data.generator_schedule:
-    schedule = envoy.data.generator_schedule
+if SupportedFeatures.GENERATOR_SCHEDULE in envoy.supported_features and (schedule := data.generator_schedule):
     print(
         f"Exercise: every {schedule.exercise_freq_in_weeks} week(s) on "
         f"{schedule.exercise_day} at minute {schedule.exercise_start} "

--- a/docs/data_ensemble.md
+++ b/docs/data_ensemble.md
@@ -87,7 +87,7 @@ await envoy.update_generator_schedule({"exercise_day": "Sat"}, refresh=True)
 
 Use it when the Enphase cloud or app may have changed settings since the last data collection, so values from stale data are not sent back.
 
-Be aware that when the Envoy returns an incomplete document as a refresh reply, the stored data for the generator_schedule is set to None to reflect the now current state in the Envoy and return EnvoyFeatureNotAvailable.
+Be aware that when the Envoy returns an incomplete document as a refresh reply, the stored data for the generator_schedule is set to None to reflect the now current state in the Envoy and raises `EnvoyFeatureNotAvailable`.
 
 On systems with Enphase batteries, note that `default_start_soc` and `default_stop_soc` are always part of the schedule document and are applied by the firmware as the active generator start/stop state of charge, as reported in [EnvoyData.generator](#pyenphase.EnvoyData.generator). Values held in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule) at the time of the call are sent, so if another application changed them since the last data collection, the update will set them back. Use `refresh=True`, call [Envoy.update](#pyenphase.Envoy.update) first, or include the wanted SOC values in the settings to change. The generator starts at `default_start_soc` and stops at `default_stop_soc`, so the start value must be lower than the stop value; the resulting pair is validated against the stored values for whichever of the two is not being changed.
 

--- a/docs/data_ensemble.md
+++ b/docs/data_ensemble.md
@@ -71,7 +71,7 @@ The Envoy class provides the method [Envoy.set_generator_mode](#pyenphase.Envoy.
 
 The generator schedule will only be available when configured in the Envoy using the Enphase tools. If not setup, the {py:attr}`pyenphase.const.SupportedFeatures.GENERATOR_SCHEDULE` flag will not be set and the {py:attr}`pyenphase.EnvoyData.generator_schedule` will be `None`. The [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) can not be used either until a schedule is configured in the Envoy.
 
-Once a schedule is configured in the Envoy, rerun {py:attr}`pyenphase.Envoy.probe` to make the schedule known in the data model.
+Once a schedule is configured in the Envoy, rerun {py:attr}`pyenphase.Envoy.probe` and {py:attr}`pyenphase.Envoy.update` to make the schedule known in the data model. If your application does not specifically uses {py:attr}`pyenphase.Envoy.probe` but rather the automatic execution of it by first use of {py:attr}`pyenphase.Envoy.update`, you will need to re-instantiate the Envoy class, which in its simplest form is re-starting your application.
 
 ---
 
@@ -108,7 +108,7 @@ if envoy.data.generator_mode:
 if envoy.data.generator_config:
     print(f"Generator: {envoy.data.generator_config.manufacturer} {envoy.data.generator_config.model}")
 
-if SupportedFeatures.GENERATOR_SCHEDULE in envoy.supported_features and (schedule := data.generator_schedule):
+if SupportedFeatures.GENERATOR_SCHEDULE in envoy.supported_features and (schedule := envoy.data.generator_schedule):
     print(
         f"Exercise: every {schedule.exercise_freq_in_weeks} week(s) on "
         f"{schedule.exercise_day} at minute {schedule.exercise_start} "

--- a/docs/data_ensemble.md
+++ b/docs/data_ensemble.md
@@ -60,20 +60,16 @@ Systems with an Enpower and a standby generator installed report generator data.
 
 - Generator status (admin, operational relay state, admin mode, schedule state, generator present) is available in [EnvoyData.generator](#pyenphase.EnvoyData.generator), modeled by [EnvoyGenerator](#pyenphase.models.generator.EnvoyGenerator).
 - Generator configuration (name plate rating, manufacturer, model, start method, warm-up/cool-down minutes) is available in [EnvoyData.generator_config](#pyenphase.EnvoyData.generator_config), modeled by [EnvoyGeneratorConfig](#pyenphase.models.generator.EnvoyGeneratorConfig).
-- The generator exercise schedule and default state-of-charge settings are available in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule), modeled by [EnvoyGeneratorSchedule](#pyenphase.models.generator.EnvoyGeneratorSchedule). The schedule is only available if the {py:attr}`pyenphase.const.SupportedFeatures.GENERATOR_SCHEDULE` flag is set.
+- The generator exercise schedule and default state-of-charge settings are available in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule), modeled by [EnvoyGeneratorSchedule](#pyenphase.models.generator.EnvoyGeneratorSchedule). The schedule is only available if the {py:attr}`pyenphase.const.SupportedFeatures.GENERATOR_SCHEDULE` flag is set. If the flag is set, generator_schedule may return None when issues exist with the schedule data.
 - The generator operation mode ("off", "on" or "auto") is available in [EnvoyData.generator_mode](#pyenphase.EnvoyData.generator_mode), modeled by [EnvoyGeneratorMode](#pyenphase.models.generator.EnvoyGeneratorMode), on firmware exposing the `/ivp/ss/gen_mode` endpoint.
 
 The Envoy class provides the method [Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) to control the generator operation mode, [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) to change the exercise schedule and default state-of-charge settings, and [Envoy.set_generator_charge_from_generator](#pyenphase.Envoy.set_generator_charge_from_generator) to allow or disallow charging batteries from the generator.
 
----
-
-**NOTE**
-
+```{note}
 The generator schedule will only be available when configured in the Envoy using the Enphase tools. If not setup, the {py:attr}`pyenphase.const.SupportedFeatures.GENERATOR_SCHEDULE` flag will not be set and the {py:attr}`pyenphase.EnvoyData.generator_schedule` will be `None`. The [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) can not be used either until a schedule is configured in the Envoy.
 
-Once a schedule is configured in the Envoy, rerun {py:attr}`pyenphase.Envoy.probe` and {py:attr}`pyenphase.Envoy.update` to make the schedule known in the data model. If your application does not specifically uses {py:attr}`pyenphase.Envoy.probe` but rather the automatic execution of it by first use of {py:attr}`pyenphase.Envoy.update`, you will need to re-instantiate the Envoy class, which in its simplest form is re-starting your application.
-
----
+Once a schedule is configured in the Envoy, rerun {py:attr}`pyenphase.Envoy.probe` and {py:attr}`pyenphase.Envoy.update` to make the schedule known in the data model. If your application does not specifically use {py:meth}`pyenphase.Envoy.probe` but rather the automatic execution of it by first use of {py:meth}`pyenphase.Envoy.update`, you will need to re-instantiate the Envoy class, which in its simplest form is re-starting your application.
+```
 
 [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) and [Envoy.set_generator_charge_from_generator](#pyenphase.Envoy.set_generator_charge_from_generator) send the whole document to the Envoy, as these endpoints do not support partial updates. The document is built from the data in [EnvoyData](#pyenphase.EnvoyData), with only the specified settings changed. ([Envoy.set_generator_mode](#pyenphase.Envoy.set_generator_mode) is a single command endpoint and does not work this way.) [Envoy.update_generator_schedule](#pyenphase.Envoy.update_generator_schedule) takes a dict of settings to change, so a single setting can be changed without specifying the others:
 
@@ -91,11 +87,14 @@ await envoy.update_generator_schedule({"exercise_day": "Sat"}, refresh=True)
 
 Use it when the Enphase cloud or app may have changed settings since the last data collection, so values from stale data are not sent back.
 
+Be aware that when the Envoy returns an incomplete document as a refresh reply, the stored data for the generator_schedule is set to None to reflect the now current state in the Envoy and return EnvoyFeatureNotAvailable.
+
 On systems with Enphase batteries, note that `default_start_soc` and `default_stop_soc` are always part of the schedule document and are applied by the firmware as the active generator start/stop state of charge, as reported in [EnvoyData.generator](#pyenphase.EnvoyData.generator). Values held in [EnvoyData.generator_schedule](#pyenphase.EnvoyData.generator_schedule) at the time of the call are sent, so if another application changed them since the last data collection, the update will set them back. Use `refresh=True`, call [Envoy.update](#pyenphase.Envoy.update) first, or include the wanted SOC values in the settings to change. The generator starts at `default_start_soc` and stops at `default_stop_soc`, so the start value must be lower than the stop value; the resulting pair is validated against the stored values for whichever of the two is not being changed.
 
 On systems without Enphase batteries the Envoy accepts a `charge_from_generator` write with HTTP 200 but normalizes the value back to `true`; do not assume `false` persisted. The returned document and the updated [EnvoyData.generator_config](#pyenphase.EnvoyData.generator_config) report the effective value.
 
 ```python
+
 if envoy.data.generator:
     print(f"Generator relay: {envoy.data.generator.oper_state}")
 
@@ -108,7 +107,7 @@ if envoy.data.generator_mode:
 if envoy.data.generator_config:
     print(f"Generator: {envoy.data.generator_config.manufacturer} {envoy.data.generator_config.model}")
 
-if SupportedFeatures.GENERATOR_SCHEDULE in envoy.supported_features and (schedule := envoy.data.generator_schedule):
+if schedule := envoy.data.generator_schedule:
     print(
         f"Exercise: every {schedule.exercise_freq_in_weeks} week(s) on "
         f"{schedule.exercise_day} at minute {schedule.exercise_start} "

--- a/src/pyenphase/const.py
+++ b/src/pyenphase/const.py
@@ -40,10 +40,13 @@ URL_ACB_CONFIG = "/admin/lib/acb_config"
 # the updater filters these out by checking admin_state != 0.
 URL_INVENTORY = "/inventory.json?deleted=1"
 
-# Generator Configuration
+#: Ensemble Generator Configuration endpoint for :any:`EnvoyGeneratorUpdater`
 URL_GENERATOR = "/ivp/ensemble/generator"
+#: Generator Configuration endpoint for :any:`EnvoyGeneratorUpdater`
 URL_GEN_CONFIG = "/ivp/ss/gen_config"
+#: Generator mode endpoint for :any:`EnvoyGeneratorUpdater`
 URL_GEN_MODE = "/ivp/ss/gen_mode"
+#: Generator schedule endpoint for :any:`EnvoyGeneratorUpdater`
 URL_GEN_SCHEDULE = "/ivp/ss/gen_schedule"
 
 #: Valid generator modes for :any:`Envoy.set_generator_mode`
@@ -147,6 +150,7 @@ class SupportedFeatures(enum.IntFlag):
     DETAILED_INVERTERS = 8192  #: Detailed inverter data is reported
     COLLAR = 0x4000  #: Envoy reports a Collar
     C6CC = 0x8000  #: Envoy reports a C6 Combiner controller
+    GENERATOR_SCHEDULE = 0x10000  #: Envoy has generator schedule defined
 
 
 class PhaseNames(enum.StrEnum):

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -1173,6 +1173,13 @@ class Envoy:
             # re-read before merging so settings changed by the Enphase
             # cloud or app since the last data collection are not echoed
             # back with stale values
+            # If we are here then probe detected a valid generator schedule.
+            # _model_from_document raises on 3 error types including KeyError.
+            # fromApi will return None in case of KeyError so we fall through
+            # and below error is not raised, no mention of `no data change`
+            # will occur. data.generator_schedule is set to None and data_raw
+            # shows last known data. Which is for both the actual current situation.
+            # The guard below will prevent actual change execution.
             current = await self._json_request(URL_GEN_SCHEDULE, None)
             data.generator_schedule = self._model_from_document(
                 URL_GEN_SCHEDULE,
@@ -1184,7 +1191,8 @@ class Envoy:
             data.raw[URL_GEN_SCHEDULE] = current
         if data.generator_schedule is None:
             raise EnvoyFeatureNotAvailable(
-                "The generator schedule endpoint is incomplete or not available on this Envoy."
+                "The generator schedule endpoint is incomplete, "
+                "has issues or is no longer available on this Envoy."
             )
         new_data = self._validated_generator_schedule(new_data, data.generator_schedule)
         # merge with the current settings and send the whole document

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -1144,6 +1144,11 @@ class Envoy:
         EnvoyCommunicationError is raised. The update was sent in that
         case, use :any:`Envoy.update` to establish the actual state.
 
+        Be aware that when the Envoy returns an incomplete document as a
+        refresh reply the stored data for the generator_schedulle is set
+        to None to reflect the now current state in the Envoy and raises
+        EnvoyFeatureNotAvailable.
+
         :param new_data: dict of settings to change
         :param refresh: re-read the schedule from the Envoy before
             merging the settings to change into it
@@ -1203,19 +1208,19 @@ class Envoy:
         # Build the model first: if the reply is not a complete document
         # the stored data is left at the last known state rather than at
         # an optimistic one the Envoy never confirmed.
+        message = (
+            "The Envoy returned an incomplete generator schedule for the update, "
+            "the update was sent but the stored data was left unchanged"
+        )
         new_state = self._model_from_document(
             URL_GEN_SCHEDULE,
             result,
             EnvoyGeneratorSchedule.from_api,
-            "The Envoy returned an incomplete generator schedule for the update, "
-            "the update was sent but the stored data was left unchanged",
+            message,
         )
         # if updated schedule is None we got incomplete reply
-        if not new_state:
-            raise EnvoyCommunicationError(
-                "The Envoy returned an incomplete generator schedule for the update, "
-                "the update was sent but the stored data was left unchanged",
-            )
+        if new_state is None:
+            raise EnvoyCommunicationError(f"{message}: {URL_GEN_SCHEDULE}")
 
         data.raw[URL_GEN_SCHEDULE] = result
         data.generator_schedule = new_state
@@ -1231,15 +1236,18 @@ class Envoy:
         """
         Build a data model from a document returned by the Envoy.
 
-        Used to verify a document returned for a write action is complete
-        before any stored data is replaced with it.
+        Used to verify a document returned before a write action
+        is executed and data is sed by the write or after a write
+        action is completeed before any stored data is replaced
+        with it. The specified from_api may return None and caller
+        should handle those cases.
 
         :param end_point: Envoy endpoint the document came from
         :param document: JSON document returned by the Envoy
         :param from_api: model method to build the model from the document
         :param message: message to report if the document is incomplete
         :raises EnvoyCommunicationError: If the document is not a complete document
-        :return: data model built from the document
+        :return: data model built from the document, may be None
         """
         try:
             return from_api(document)

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -1147,7 +1147,8 @@ class Envoy:
         :param new_data: dict of settings to change
         :param refresh: re-read the schedule from the Envoy before
             merging the settings to change into it
-        :raises EnvoyFeatureNotAvailable: If GENERATOR feature is not available in Envoy
+        :raises EnvoyFeatureNotAvailable: If GENERATOR or GENERATOR_SCHEDULE
+            feature is not available in Envoy
         :raises EnvoyFeatureNotAvailable: If this firmware does not expose the gen_schedule endpoint
         :raises ValueError: If update was attempted before first data was requested from Envoy
         :raises ValueError: If an unknown setting is specified or a value is out of range
@@ -1157,17 +1158,16 @@ class Envoy:
         :raises EnvoyHTTPStatusError: when HTTP status is not 2xx.
         :return: generator schedule JSON returned by Envoy
         """
-        if not self.supported_features & SupportedFeatures.GENERATOR:
+        if (
+            not self.supported_features & SupportedFeatures.GENERATOR
+            or not self.supported_features & SupportedFeatures.GENERATOR_SCHEDULE
+        ):
             raise EnvoyFeatureNotAvailable(
                 "This feature is not available on this Envoy."
             )
         if not (data := self.data):
             raise ValueError(
                 "Tried to set generator schedule before the Envoy was queried."
-            )
-        if data.generator_schedule is None:
-            raise EnvoyFeatureNotAvailable(
-                "The generator schedule endpoint is not available on this Envoy."
             )
         if refresh:
             # re-read before merging so settings changed by the Enphase
@@ -1182,6 +1182,10 @@ class Envoy:
                 "no data was changed and no update was sent",
             )
             data.raw[URL_GEN_SCHEDULE] = current
+        if data.generator_schedule is None:
+            raise EnvoyFeatureNotAvailable(
+                "The generator schedule endpoint is incomplete or not available on this Envoy."
+            )
         new_data = self._validated_generator_schedule(new_data, data.generator_schedule)
         # merge with the current settings and send the whole document
         new_model = replace(data.generator_schedule, **new_data)
@@ -1198,6 +1202,13 @@ class Envoy:
             "The Envoy returned an incomplete generator schedule for the update, "
             "the update was sent but the stored data was left unchanged",
         )
+        # if updated schedule is None we got incomplete reply
+        if not new_state:
+            raise EnvoyCommunicationError(
+                "The Envoy returned an incomplete generator schedule for the update, "
+                "the update was sent but the stored data was left unchanged",
+            )
+
         data.raw[URL_GEN_SCHEDULE] = result
         data.generator_schedule = new_state
         return result

--- a/src/pyenphase/envoy.py
+++ b/src/pyenphase/envoy.py
@@ -1145,7 +1145,7 @@ class Envoy:
         case, use :any:`Envoy.update` to establish the actual state.
 
         Be aware that when the Envoy returns an incomplete document as a
-        refresh reply the stored data for the generator_schedulle is set
+        refresh reply the stored data for the generator_schedule is set
         to None to reflect the now current state in the Envoy and raises
         EnvoyFeatureNotAvailable.
 
@@ -1237,8 +1237,8 @@ class Envoy:
         Build a data model from a document returned by the Envoy.
 
         Used to verify a document returned before a write action
-        is executed and data is sed by the write or after a write
-        action is completeed before any stored data is replaced
+        is executed and data is send by the write or after a write
+        action is completed before any stored data is replaced
         with it. The specified from_api may return None and caller
         should handle those cases.
 

--- a/src/pyenphase/models/generator.py
+++ b/src/pyenphase/models/generator.py
@@ -161,13 +161,13 @@ class EnvoyGeneratorSchedule:
         Initialize class from API json data.
 
         Exercise_config is only included in the generator schedule when
-        configured in the Envoy using the App. Without the exercise_schedule
+        configured in the Envoy using the App. Without the exercise_config
         the EnvoyGeneratorSchedule is not usable. Other components presence
         is assumed. If any are missing return None, let caller handle this.
         This makes from_api usable as verification during probe.
 
         :param schedule: json returned by :any:`URL_GEN_SCHEDULE`
-        :return: populated EnvoyGeneratorSchedule class or None if exercise_schedule or other keys are missing
+        :return: populated EnvoyGeneratorSchedule class or None if exercise_config or other keys are missing
         """
         try:
             exercise_config = schedule["exercise_config"]

--- a/src/pyenphase/models/generator.py
+++ b/src/pyenphase/models/generator.py
@@ -160,7 +160,7 @@ class EnvoyGeneratorSchedule:
         """
         Initialize class from API json data.
 
-        Exerscise_config is only included in the generator schedule when
+        Exercise_config is only included in the generator schedule when
         configured in the Envoy using the App. Without the exercise_schedule
         the EnvoyGeneratorSchedule is not usable. Other components presence
         is assumed. If any are missing return None, let caller handle this.
@@ -182,7 +182,7 @@ class EnvoyGeneratorSchedule:
                 last_updated_by=schedule["last_updated_by"],
                 schedule=schedule["schedule"],
             )
-        except KeyError:
+        except (KeyError, TypeError, IndexError):
             generator_schedule = None
         return generator_schedule
 

--- a/src/pyenphase/models/generator.py
+++ b/src/pyenphase/models/generator.py
@@ -156,20 +156,35 @@ class EnvoyGeneratorSchedule:
     schedule: dict[str, Any]
 
     @classmethod
-    def from_api(cls, schedule: dict[str, Any]) -> EnvoyGeneratorSchedule:
-        """Initialize from the API."""
-        exercise_config = schedule["exercise_config"]
-        default_soc = schedule["default_soc"]
-        return cls(
-            exercise_freq_in_weeks=exercise_config["freq_in_weeks"],
-            exercise_start=exercise_config["start"],
-            exercise_duration=exercise_config["duration"],
-            exercise_day=exercise_config["day"],
-            default_start_soc=default_soc["start_soc"],
-            default_stop_soc=default_soc["stop_soc"],
-            last_updated_by=schedule["last_updated_by"],
-            schedule=schedule["schedule"],
-        )
+    def from_api(cls, schedule: dict[str, Any]) -> EnvoyGeneratorSchedule | None:
+        """
+        Initialize class from API json data.
+
+        Exerscise_config is only included in the generator schedule when
+        configured in the Envoy using the App. Without the exercise_schedule
+        the EnvoyGeneratorSchedule is not usable. Other components presence
+        is assumed. If any are missing return None, let caller handle this.
+        This makes from_api usable as verification during probe.
+
+        :param schedule: json returned by :any:`URL_GEN_SCHEDULE`
+        :return: populated EnvoyGeneratorSchedule class or None if exercise_schedule or other keys are missing
+        """
+        try:
+            exercise_config = schedule["exercise_config"]
+            default_soc = schedule["default_soc"]
+            generator_schedule = cls(
+                exercise_freq_in_weeks=exercise_config["freq_in_weeks"],
+                exercise_start=exercise_config["start"],
+                exercise_duration=exercise_config["duration"],
+                exercise_day=exercise_config["day"],
+                default_start_soc=default_soc["start_soc"],
+                default_stop_soc=default_soc["stop_soc"],
+                last_updated_by=schedule["last_updated_by"],
+                schedule=schedule["schedule"],
+            )
+        except KeyError:
+            generator_schedule = None
+        return generator_schedule
 
     def to_api(self) -> dict[str, Any]:
         """Convert to API format."""

--- a/src/pyenphase/updaters/generator.py
+++ b/src/pyenphase/updaters/generator.py
@@ -106,7 +106,7 @@ class EnvoyGeneratorUpdater(EnvoyUpdater):
         self._generator_available = await self._optional_endpoint_available(
             URL_GENERATOR
         )
-        # verify data for missing exercise_schedule
+        # verify data for missing exercise_config
         self._gen_schedule_available = await self._optional_endpoint_available(
             URL_GEN_SCHEDULE, EnvoyGeneratorSchedule.from_api
         )
@@ -139,6 +139,8 @@ class EnvoyGeneratorUpdater(EnvoyUpdater):
             envoy_data.generator_schedule = EnvoyGeneratorSchedule.from_api(
                 generator_schedule_data
             )
+            if not envoy_data.generator_schedule:
+                _LOGGER.debug("Generator Schedule returned None.")
 
         if self._gen_mode_available:
             generator_mode_data: dict[str, Any] = await self._json_request(URL_GEN_MODE)

--- a/src/pyenphase/updaters/generator.py
+++ b/src/pyenphase/updaters/generator.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from typing import Any
 
 from ..const import (
@@ -32,11 +33,16 @@ class EnvoyGeneratorUpdater(EnvoyUpdater):
     #: Whether the Envoy exposes the gen_mode endpoint, set during probe
     _gen_mode_available: bool = False
 
-    async def _optional_endpoint_available(self, end_point: str) -> bool:
+    async def _optional_endpoint_available(
+        self, end_point: str, verify_method: Callable[..., Any] | None = None
+    ) -> bool:
         """
         Probe an optional generator endpoint and report its availability.
+        Optionally verify endpoint data validity using the verify method.
 
         :param end_point: Envoy endpoint to probe
+        :param verify_method: If specified used to verify endpoint data.
+            Bool result of verify method is returned instead of bool result of probe request
         :return: True if the endpoint returned usable data
         """
         try:
@@ -44,12 +50,36 @@ class EnvoyGeneratorUpdater(EnvoyUpdater):
         except ENDPOINT_PROBE_EXCEPTIONS as e:
             _LOGGER.debug("Generator endpoint not found at %s: %s", end_point, e)
             return False
-        return bool(result) and "error" not in result and "err" not in result
+        # Newer firmware with no generator configured returns an empty dict
+        if not bool(result) or "err" in result:
+            _LOGGER.debug("Generator endpoint not found at %s", end_point)
+            return False
+        if verify_method:
+            # verify returned data validity
+            result = verify_method(result)
+            _LOGGER.debug(
+                "Generator endpoint %s data passed verification: %s",
+                end_point,
+                bool(result),
+            )
+            return bool(result)
+        return True
 
     async def probe(
         self, discovered_features: SupportedFeatures
     ) -> SupportedFeatures | None:
-        """Probe the Envoy for this updater and return SupportedFeatures."""
+        """
+        Probe the Envoy for this updater and return found generator features.
+
+        May set :any:`SupportedFeatures.GENERATOR` or
+        :any:`SupportedFeatures.GENERATOR_SCHEDULE`.
+
+        Probes endpoints :any:`URL_GEN_CONFIG`, :any:`URL_GENERATOR`,
+        :any:`URL_GEN_SCHEDULE` and :any:`URL_GEN_MODE`
+
+        Requires :any:`SupportedFeatures.ENPOWER` to be set,
+        if not, no probe efforts are done and None is returned.
+        """
         if self._envoy_version < ENSEMBLE_MIN_VERSION:
             _LOGGER.debug("Firmware too old for Ensemble support")
             return None
@@ -59,32 +89,30 @@ class EnvoyGeneratorUpdater(EnvoyUpdater):
             return None
 
         # Check for generator support
-        try:
-            result = await self._json_probe_request(URL_GEN_CONFIG)
-        except ENDPOINT_PROBE_EXCEPTIONS as e:
-            _LOGGER.debug("Generator config endpoint not found: %s", e)
-        else:
-            if not result or "error" in result or "err" in result:
-                # Newer firmware with no generator configured returns an empty dict
-                _LOGGER.debug("No generator found")
-                return None
+        result = await self._optional_endpoint_available(URL_GEN_CONFIG)
+        if not result:
+            _LOGGER.debug("No generator configuration found")
+            return None
 
-            self._supported_features |= SupportedFeatures.GENERATOR
+        self._supported_features |= SupportedFeatures.GENERATOR
 
-            # The generator status, schedule and operation mode live in
-            # separate endpoints that are not all present on every
-            # generator-capable firmware. Probe each one so update() only
-            # fetches what is available and the corresponding data fields
-            # degrade independently to None.
-            self._generator_available = await self._optional_endpoint_available(
-                URL_GENERATOR
-            )
-            self._gen_schedule_available = await self._optional_endpoint_available(
-                URL_GEN_SCHEDULE
-            )
-            self._gen_mode_available = await self._optional_endpoint_available(
-                URL_GEN_MODE
-            )
+        # The generator status, schedule and operation mode live in
+        # separate endpoints that are not all present on every
+        # generator-capable firmware. Probe each one so update() only
+        # fetches what is available and the corresponding data fields
+        # degrade independently to None.
+        self._generator_available = await self._optional_endpoint_available(
+            URL_GENERATOR
+        )
+        # verify data for missing exercise_schedule
+        self._gen_schedule_available = await self._optional_endpoint_available(
+            URL_GEN_SCHEDULE, EnvoyGeneratorSchedule.from_api
+        )
+        # if valid schedule signal availability to clients so they can use it as guard
+        if self._gen_schedule_available:
+            self._supported_features |= SupportedFeatures.GENERATOR_SCHEDULE
+
+        self._gen_mode_available = await self._optional_endpoint_available(URL_GEN_MODE)
 
         return self._supported_features
 

--- a/src/pyenphase/updaters/generator.py
+++ b/src/pyenphase/updaters/generator.py
@@ -34,7 +34,9 @@ class EnvoyGeneratorUpdater(EnvoyUpdater):
     _gen_mode_available: bool = False
 
     async def _optional_endpoint_available(
-        self, end_point: str, verify_method: Callable[..., Any] | None = None
+        self,
+        end_point: str,
+        verify_method: Callable[[dict[str, Any]], object] | None = None,
     ) -> bool:
         """
         Probe an optional generator endpoint and report its availability.
@@ -51,18 +53,18 @@ class EnvoyGeneratorUpdater(EnvoyUpdater):
             _LOGGER.debug("Generator endpoint not found at %s: %s", end_point, e)
             return False
         # Newer firmware with no generator configured returns an empty dict
-        if not bool(result) or "err" in result:
-            _LOGGER.debug("Generator endpoint not found at %s", end_point)
+        if not bool(result) or "error" in result or "err" in result:
+            _LOGGER.debug("No usable Generator data at %s", end_point)
             return False
         if verify_method:
             # verify returned data validity
-            result = verify_method(result)
+            verified = verify_method(result)
             _LOGGER.debug(
                 "Generator endpoint %s data passed verification: %s",
                 end_point,
-                bool(result),
+                bool(verified),
             )
-            return bool(result)
+            return bool(verified)
         return True
 
     async def probe(

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -509,7 +509,8 @@ LOGGER = logging.getLogger(__name__)
             | SupportedFeatures.TARIFF
             | SupportedFeatures.DUALPHASE
             | SupportedFeatures.CTMETERS
-            | SupportedFeatures.GENERATOR,
+            | SupportedFeatures.GENERATOR
+            | SupportedFeatures.GENERATOR_SCHEDULE,
             {
                 "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
                 "EnvoyEnembleUpdater": SupportedFeatures.ENCHARGE
@@ -521,7 +522,8 @@ LOGGER = logging.getLogger(__name__)
                 "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
                 "EnvoyMetersUpdater": SupportedFeatures.DUALPHASE
                 | SupportedFeatures.CTMETERS,
-                "EnvoyGeneratorUpdater": SupportedFeatures.GENERATOR,
+                "EnvoyGeneratorUpdater": SupportedFeatures.GENERATOR
+                | SupportedFeatures.GENERATOR_SCHEDULE,
             },
             2,
             {},

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -360,7 +360,8 @@ LOGGER = logging.getLogger(__name__)
             | SupportedFeatures.TARIFF
             | SupportedFeatures.DUALPHASE
             | SupportedFeatures.CTMETERS
-            | SupportedFeatures.GENERATOR,
+            | SupportedFeatures.GENERATOR
+            | SupportedFeatures.GENERATOR_SCHEDULE,
             {
                 "EnvoyApiV1ProductionInvertersUpdater": SupportedFeatures.INVERTERS,
                 "EnvoyEnembleUpdater": SupportedFeatures.ENCHARGE
@@ -372,7 +373,8 @@ LOGGER = logging.getLogger(__name__)
                 "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
                 "EnvoyMetersUpdater": SupportedFeatures.DUALPHASE
                 | SupportedFeatures.CTMETERS,
-                "EnvoyGeneratorUpdater": SupportedFeatures.GENERATOR,
+                "EnvoyGeneratorUpdater": SupportedFeatures.GENERATOR
+                | SupportedFeatures.GENERATOR_SCHEDULE,
             },
         ),
         (
@@ -388,7 +390,8 @@ LOGGER = logging.getLogger(__name__)
             | SupportedFeatures.TARIFF
             | SupportedFeatures.DUALPHASE
             | SupportedFeatures.CTMETERS
-            | SupportedFeatures.GENERATOR,
+            | SupportedFeatures.GENERATOR
+            | SupportedFeatures.GENERATOR_SCHEDULE,
             {
                 "EnvoyDeviceDataInvertersUpdater": SupportedFeatures.INVERTERS
                 | SupportedFeatures.DETAILED_INVERTERS,
@@ -401,7 +404,8 @@ LOGGER = logging.getLogger(__name__)
                 "EnvoyTariffUpdater": SupportedFeatures.TARIFF,
                 "EnvoyMetersUpdater": SupportedFeatures.DUALPHASE
                 | SupportedFeatures.CTMETERS,
-                "EnvoyGeneratorUpdater": SupportedFeatures.GENERATOR,
+                "EnvoyGeneratorUpdater": SupportedFeatures.GENERATOR
+                | SupportedFeatures.GENERATOR_SCHEDULE,
             },
         ),
         (

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -299,3 +299,48 @@ async def test_set_generator_mode(
     # invalid modes are rejected without sending a request
     with pytest.raises(ValueError):
         await envoy.set_generator_mode("standby")
+
+
+@pytest.mark.asyncio
+async def test_generator_missing_exercise_schedule(
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify generator data degrades if no exercise schedule is present in schedule."""
+    version = "8.3.5169_with_generator"
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", version)
+
+    full_host = endpoint_path(version, "127.0.0.1")
+
+    # Simulate a firmware variant that reports schedule without exercise
+    schedule_json = await load_json_fixture(version, "ivp_ss_gen_schedule")
+    del schedule_json["exercise_config"]
+
+    override_mock(
+        mock_aioresponse,
+        "get",
+        f"{full_host}{URL_GEN_SCHEDULE}",
+        status=200,
+        payload=schedule_json,
+        repeat=True,
+    )
+    envoy = await get_mock_envoy(test_client_session)
+
+    # gen_config alone still flags generator support
+    assert envoy.supported_features & SupportedFeatures.GENERATOR
+
+    # generator schedule should not be signalled
+    assert not (envoy.supported_features & SupportedFeatures.GENERATOR_SCHEDULE)
+
+    data = envoy.data
+    assert data is not None
+    # config and mode populated, schedule degrades to None
+    assert data.generator_config is not None
+    assert URL_GEN_CONFIG in data.raw
+    assert data.generator is not None
+    assert data.generator_schedule is None
+    assert data.generator_mode is not None
+    assert URL_GENERATOR in data.raw
+    assert URL_GEN_SCHEDULE not in data.raw
+    assert URL_GEN_MODE in data.raw

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -302,11 +302,11 @@ async def test_set_generator_mode(
 
 
 @pytest.mark.asyncio
-async def test_generator_missing_exercise_schedule(
+async def test_generator_missing_exercise_config(
     mock_aioresponse: aioresponses,
     test_client_session: aiohttp.ClientSession,
 ) -> None:
-    """Verify generator data degrades if no exercise schedule is present in schedule."""
+    """Verify generator data degrades if no exercise config is present in schedule."""
     version = "8.3.5169_with_generator"
     start_7_firmware_mock(mock_aioresponse)
     await prep_envoy(mock_aioresponse, "127.0.0.1", version)
@@ -343,4 +343,53 @@ async def test_generator_missing_exercise_schedule(
     assert data.generator_mode is not None
     assert URL_GENERATOR in data.raw
     assert URL_GEN_SCHEDULE not in data.raw
+    assert URL_GEN_MODE in data.raw
+
+    # start with working generator schedule
+    schedule_json = await load_json_fixture(version, "ivp_ss_gen_schedule")
+
+    override_mock(
+        mock_aioresponse,
+        "get",
+        f"{full_host}{URL_GEN_SCHEDULE}",
+        status=200,
+        payload=schedule_json,
+        repeat=True,
+    )
+    envoy = await get_mock_envoy(test_client_session)
+
+    data = envoy.data
+    assert SupportedFeatures.GENERATOR_SCHEDULE in envoy.supported_features
+    assert data is not None
+    assert data.generator_config is not None
+    assert URL_GEN_CONFIG in data.raw
+    assert data.generator is not None
+    assert data.generator_schedule is not None
+    assert data.generator_mode is not None
+    assert URL_GENERATOR in data.raw
+    assert URL_GEN_SCHEDULE in data.raw
+    assert URL_GEN_MODE in data.raw
+
+    # now simulated failed schedule
+    del schedule_json["exercise_config"]
+
+    override_mock(
+        mock_aioresponse,
+        "get",
+        f"{full_host}{URL_GEN_SCHEDULE}",
+        status=200,
+        payload=schedule_json,
+        repeat=True,
+    )
+    await envoy.update()
+    data = envoy.data
+    assert SupportedFeatures.GENERATOR_SCHEDULE in envoy.supported_features
+    assert data is not None
+    assert data.generator_config is not None
+    assert URL_GEN_CONFIG in data.raw
+    assert data.generator is not None
+    assert data.generator_schedule is None
+    assert data.generator_mode is not None
+    assert URL_GENERATOR in data.raw
+    assert URL_GEN_SCHEDULE in data.raw
     assert URL_GEN_MODE in data.raw

--- a/tests/test_generator_write.py
+++ b/tests/test_generator_write.py
@@ -509,7 +509,7 @@ async def test_generator_write_refresh_incomplete(
 
 
 @pytest.mark.asyncio
-async def test_update_generator_schedule_without_exercise_schedule(
+async def test_update_generator_schedule_without_exercise_config(
     mock_aioresponse: aioresponses,
     test_client_session: aiohttp.ClientSession,
 ) -> None:

--- a/tests/test_generator_write.py
+++ b/tests/test_generator_write.py
@@ -342,13 +342,15 @@ async def test_update_generator_schedule_incomplete_reply(
     mock_aioresponse: aioresponses,
     test_client_session: aiohttp.ClientSession,
 ) -> None:
-    """Verify stored data is kept if the Envoy returns no complete schedule."""
+    """Verify stored data is kept if the Envoy returns no complete schedule on schedule update."""
     start_7_firmware_mock(mock_aioresponse)
     await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
     caplog.set_level(logging.DEBUG)
 
     envoy = await get_mock_envoy(test_client_session)
     schedule_json = await load_json_fixture(VERSION, "ivp_ss_gen_schedule")
+    assert envoy.data
+    assert envoy.data.generator_schedule
     full_host = endpoint_path(VERSION, envoy.host)
     mock_aioresponse.post(
         f"{full_host}{URL_GEN_SCHEDULE}", status=200, payload=reply, repeat=True
@@ -494,7 +496,7 @@ async def test_generator_write_refresh_incomplete(
             repeat=True,
         )
 
-    with pytest.raises(EnvoyCommunicationError):
+    with pytest.raises(EnvoyFeatureNotAvailable):
         await envoy.update_generator_schedule({"exercise_duration": 50}, refresh=True)
     with pytest.raises(EnvoyCommunicationError):
         await envoy.set_generator_charge_from_generator(False, refresh=True)
@@ -504,3 +506,36 @@ async def test_generator_write_refresh_incomplete(
     assert cnt == 0
     cnt, _data = latest_request(mock_aioresponse, "POST", URL_GEN_CONFIG)
     assert cnt == 0
+
+
+@pytest.mark.asyncio
+async def test_update_generator_schedule_without_exercise_schedule(
+    mock_aioresponse: aioresponses,
+    test_client_session: aiohttp.ClientSession,
+) -> None:
+    """Verify the schedule update rejects firmware without the exercise in gen_schedule endpoint."""
+    start_7_firmware_mock(mock_aioresponse)
+    await prep_envoy(mock_aioresponse, "127.0.0.1", VERSION)
+
+    # Simulate a firmware variant with gen_config but no gen_schedule endpoint
+    full_host = endpoint_path(VERSION, "127.0.0.1")
+
+    # Simulate a firmware variant that reports schedule without exercise
+    schedule_json = await load_json_fixture(VERSION, "ivp_ss_gen_schedule")
+    del schedule_json["exercise_config"]
+
+    override_mock(
+        mock_aioresponse,
+        "get",
+        f"{full_host}{URL_GEN_SCHEDULE}",
+        status=200,
+        payload=schedule_json,
+        repeat=True,
+    )
+    envoy = await get_mock_envoy(test_client_session)
+    assert envoy.supported_features & SupportedFeatures.GENERATOR
+    assert envoy.data is not None
+    assert envoy.data.generator_schedule is None
+
+    with pytest.raises(EnvoyFeatureNotAvailable):
+        await envoy.update_generator_schedule({"exercise_duration": 20})


### PR DESCRIPTION
The new generator-schedule support added in [pyenphase 3.2.0](https://github.com/pyenphase/pyenphase/releases/tag/v3.2.0) reports[ `KeyError 'exercise_config' `](https://github.com/home-assistant/core/issues/179917) when used with a generator without a configured exercise schedule in the Envoy.

It turns out that the exercise_schedule part of the generator schedule retrieved from /ivp/ss/gen_schedule has no key `exercise_config` if the schedule is not defined in the Envoy. The exercise schedule can be configured using Enphase tools, but it is not required to configure an exercise schedule in the Envoy. An actual generator exercise schedule can also be configured through other generator tools and these are not visible for the Envoy.

This issue breaks probe and prohibits Home Assistant from loading the Enphase_envoy integration. It breaks prior successful use of the integration for Envoy with installed generator but no exercise schedule in the Envoy.

Overall a missing 'exercise_config' is a valid situation for an Envoy with a generator and should not lead to a raised KeyError. If the exercise_schedule key is missing, it implies there is no schedule configured in the Envoy and the schedule should be considered not present to avoid any of the update methods to change such a non-existing schedule.

This PR repairs any raising of `KeyError` in this case:

- A new SupportedFeatures GENERATOR_SCHEDULE flag has been added that should be used to asses  if a valid schedule exists
- The EnvoyGeneratorSchedule model `from_api()` will return None on any `KeyError`. Generator support is newly added in 3.2.0. and actual run-time is limited. For now fail on the safe side to avoid integration loading issues in Home Assistant.
-  The EnvoyGeneratorUpdater updater `probe()` now uses the EnvoyGeneratorSchedule model `from_api()` method to determine if the generator schedule is valid and if so, set SupportedFeatures GENERATOR_SCHEDULE. The `_optional_endpoint_available` has been optimized for this.
- The Envoy method `update_generator_schedule()` use the new  SupportedFeatures GENERATOR_SCHEDULE guard to prevent execution if no schedule is present.
- Test scripts test_endpoints.py and test_ensemble.py have been update for the new SupportedFeatures GENERATOR_SCHEDULE flag presence on generator fixtures.
- Test script test_generator.py and test_generator_write.py both have a new test case for missing exercise_script key.
- Documentation for the Generator section in data_ensemble.md has been updated to describe the issue and new flags.
- Various docstrings have been updated for new behavior and ref links. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate detection for generator schedule availability.
  * Generator schedule updates now validate responses before accepting them.

* **Bug Fixes**
  * Improved handling of incomplete or malformed schedule data without affecting other generator information.
  * Prevented unsuccessful schedule updates from being reported as complete.
  * Incomplete refresh responses now clear stale schedule data and report the feature as unavailable.

* **Documentation**
  * Clarified schedule refresh requirements, setup guidance, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->