### PR TITLE
ci: nail gitpython to 3.1.59 for now to fix semantic release problem

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -698,6 +698,40 @@ files = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+description = "Git Object Database"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf"},
+    {file = "gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571"},
+]
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.59"
+description = "GitPython is a Python library used to interact with Git repositories"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c"},
+    {file = "gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4"},
+]
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[package.extras]
+doc = ["sphinx (>=7.4.7,<8)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
+test = ["basedpyright (==1.39.9) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
+
+[[package]]
 name = "identify"
 version = "2.6.14"
 description = "File identification library for Python"
@@ -1716,6 +1750,18 @@ test = ["PySocks (>=1.5.6,!=1.5.7)", "pytest (>=3)", "pytest-cov", "pytest-httpb
 use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
+name = "smmap"
+version = "5.0.3"
+description = "A pure Python implementation of a sliding window memory map manager"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f"},
+    {file = "smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c"},
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
@@ -2229,4 +2275,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "9e4d291384892313f63a720f68ab51b033c000e870ec175a470a16ac49386745"
+content-hash = "4cbf2ac0ebb3ba4bacb4f6c8019988a4fe84b8630ecbc09647073bdcc85196cd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ awesomeversion = ">=22.9.0"
 tenacity = ">=8.2.2,<10.0.0"
 envoy-utils = ">=0.0.1"
 orjson = ">=3.10"
+gitpython = "3.1.59"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7,<10"


### PR DESCRIPTION
[Latest CI ](https://github.com/pyenphase/pyenphase/actions/runs/32885098627/job/98084173092)failed on release step with 

```
Error:  type object 'Actor' has no attribute 'name_email_regex'
```

Gitpython 3.1.60 was released with a changed Actor object. This results in the error ([1475](https://github.com/python-semantic-release/python-semantic-release/issues/1475),[1476](https://github.com/python-semantic-release/python-semantic-release/issues/1476)).

This prevents release of pyenphase 4.1.0.

For now fix gitpython to 3.1.59 until semantic-release releases an updated version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Git repository integration support as a runtime dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->